### PR TITLE
Use appropriate default values for OpenAPI object fields

### DIFF
--- a/openapi_core/components.py
+++ b/openapi_core/components.py
@@ -24,10 +24,10 @@ class ComponentsFactory(object):
     def create(self, components_spec):
         components_deref = self.dereferencer.dereference(components_spec)
 
-        schemas_spec = components_deref.get('schemas', [])
-        responses_spec = components_deref.get('responses', [])
-        parameters_spec = components_deref.get('parameters', [])
-        request_bodies_spec = components_deref.get('request_bodies', [])
+        schemas_spec = components_deref.get('schemas', {})
+        responses_spec = components_deref.get('responses', {})
+        parameters_spec = components_deref.get('parameters', {})
+        request_bodies_spec = components_deref.get('request_bodies', {})
 
         schemas = self.schemas_generator.generate(schemas_spec)
         responses = self._generate_response(responses_spec)

--- a/openapi_core/specs.py
+++ b/openapi_core/specs.py
@@ -77,10 +77,10 @@ class SpecFactory(object):
 
         spec_dict_deref = self.dereferencer.dereference(spec_dict)
 
-        info_spec = spec_dict_deref.get('info', [])
+        info_spec = spec_dict_deref.get('info', {})
         servers_spec = spec_dict_deref.get('servers', [])
-        paths = spec_dict_deref.get('paths', [])
-        components_spec = spec_dict_deref.get('components', [])
+        paths = spec_dict_deref.get('paths', {})
+        components_spec = spec_dict_deref.get('components', {})
 
         info = self.info_factory.create(info_spec)
         servers = self.servers_generator.generate(servers_spec)


### PR DESCRIPTION
The specification:

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#schema

clearly states that fields:

- #/info
- #/paths
- #/components
- #/components/schemas
- #/components/responses
- #/components/parameters
- #/components/requestBodies

are objects.