### PR TITLE
Add the default value for the 'servers' array

### DIFF
--- a/openapi_core/components.py
+++ b/openapi_core/components.py
@@ -24,10 +24,10 @@ class ComponentsFactory(object):
     def create(self, components_spec):
         components_deref = self.dereferencer.dereference(components_spec)
 
-        schemas_spec = components_deref.get('schemas', [])
-        responses_spec = components_deref.get('responses', [])
-        parameters_spec = components_deref.get('parameters', [])
-        request_bodies_spec = components_deref.get('request_bodies', [])
+        schemas_spec = components_deref.get('schemas', {})
+        responses_spec = components_deref.get('responses', {})
+        parameters_spec = components_deref.get('parameters', {})
+        request_bodies_spec = components_deref.get('request_bodies', {})
 
         schemas = self.schemas_generator.generate(schemas_spec)
         responses = self._generate_response(responses_spec)

--- a/openapi_core/operations.py
+++ b/openapi_core/operations.py
@@ -4,6 +4,7 @@ import logging
 from functools import lru_cache
 
 from six import iteritems
+from openapi_spec_validator.validators import PathItemValidator
 
 from openapi_core.exceptions import InvalidResponse
 from openapi_core.parameters import ParametersGenerator
@@ -56,7 +57,7 @@ class OperationsGenerator(object):
     def generate(self, path_name, path):
         path_deref = self.dereferencer.dereference(path)
         for http_method, operation in iteritems(path_deref):
-            if http_method.startswith('x-') or http_method == 'parameters':
+            if http_method not in PathItemValidator.OPERATIONS:
                 continue
 
             operation_deref = self.dereferencer.dereference(operation)

--- a/openapi_core/servers.py
+++ b/openapi_core/servers.py
@@ -41,6 +41,9 @@ class ServersGenerator(object):
 
     def generate(self, servers_spec):
         servers_deref = self.dereferencer.dereference(servers_spec)
+        if not servers_deref:
+            yield Server('/')
+            return
         for server_spec in servers_deref:
             url = server_spec['url']
             variables_spec = server_spec.get('variables', {})
@@ -64,9 +67,6 @@ class ServerVariablesGenerator(object):
 
     def generate(self, variables_spec):
         variables_deref = self.dereferencer.dereference(variables_spec)
-
-        if not variables_deref:
-            return
 
         for variable_name, variable_spec in iteritems(variables_deref):
             default = variable_spec['default']

--- a/openapi_core/servers.py
+++ b/openapi_core/servers.py
@@ -66,7 +66,7 @@ class ServerVariablesGenerator(object):
         variables_deref = self.dereferencer.dereference(variables_spec)
 
         if not variables_deref:
-            return [Server('/'), ]
+            return
 
         for variable_name, variable_spec in iteritems(variables_deref):
             default = variable_spec['default']

--- a/openapi_core/specs.py
+++ b/openapi_core/specs.py
@@ -77,10 +77,10 @@ class SpecFactory(object):
 
         spec_dict_deref = self.dereferencer.dereference(spec_dict)
 
-        info_spec = spec_dict_deref.get('info', [])
+        info_spec = spec_dict_deref.get('info', {})
         servers_spec = spec_dict_deref.get('servers', [])
-        paths = spec_dict_deref.get('paths', [])
-        components_spec = spec_dict_deref.get('components', [])
+        paths = spec_dict_deref.get('paths', {})
+        components_spec = spec_dict_deref.get('components', {})
 
         info = self.info_factory.create(info_spec)
         servers = self.servers_generator.generate(servers_spec)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 openapi-spec-validator
 six
+yarl

--- a/tests/integration/data/v3.0/minimal.yaml
+++ b/tests/integration/data/v3.0/minimal.yaml
@@ -1,0 +1,10 @@
+openapi: "3.0.0"
+info:
+  title: Minimal valid OpenAPI specification
+  version: "0.1"
+paths:
+  /status:
+    get:
+      responses:
+        default:
+          description: Return the API status.

--- a/tests/integration/data/v3.0/minimal_with_servers.yaml
+++ b/tests/integration/data/v3.0/minimal_with_servers.yaml
@@ -1,0 +1,12 @@
+openapi: "3.0.0"
+info:
+  title: Minimal valid OpenAPI specification with explicit 'servers' array
+  version: "0.1"
+servers:
+  - url: /
+paths:
+  /status:
+    get:
+      responses:
+        default:
+          description: Return the API status.

--- a/tests/integration/test_minimal.py
+++ b/tests/integration/test_minimal.py
@@ -1,0 +1,49 @@
+import pytest
+
+from openapi_core.exceptions import InvalidOperation
+from openapi_core.shortcuts import create_spec
+from openapi_core.validators import RequestValidator
+from openapi_core.wrappers import MockRequest
+
+
+class TestMinimal(object):
+
+    servers = [
+        "http://minimal.test/",
+        "https://bad.remote.domain.net/",
+        "http://localhost",
+        "http://localhost:8080",
+        "https://u:p@a.b:1337"
+    ]
+
+    spec_paths = [
+        "data/v3.0/minimal_with_servers.yaml",
+        "data/v3.0/minimal.yaml"
+    ]
+
+    @pytest.mark.parametrize("server", servers)
+    @pytest.mark.parametrize("spec_path", spec_paths)
+    def test_hosts(self, factory, server, spec_path):
+        spec_dict = factory.spec_from_file(spec_path)
+        spec = create_spec(spec_dict)
+        validator = RequestValidator(spec)
+        request = MockRequest(server, "get", "/status")
+
+        result = validator.validate(request)
+
+        assert not result.errors
+
+    @pytest.mark.parametrize("server", servers)
+    @pytest.mark.parametrize("spec_path", spec_paths)
+    def test_invalid_operation(self, factory, server, spec_path):
+        spec_dict = factory.spec_from_file(spec_path)
+        spec = create_spec(spec_dict)
+        validator = RequestValidator(spec)
+        request = MockRequest(server, "get", "/nonexistent")
+
+        result = validator.validate(request)
+
+        assert len(result.errors) == 1
+        assert isinstance(result.errors[0], InvalidOperation)
+        assert result.body is None
+        assert result.parameters == {}


### PR DESCRIPTION
The specification:

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#oasObject

requires that if the `servers` array is not provided or empty,
its default value is an array of a single `Server Object`
with `url` of `/`.

This can only be merged after PRs #13 and #14 are merged.