### PR TITLE
Fixing Subschema Required Properties Validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Jetbrains project files
+.idea/

--- a/openapi_core/__init__.py
+++ b/openapi_core/__init__.py
@@ -5,7 +5,7 @@ from openapi_core.shortcuts import (
 
 __author__ = 'Artur Maciąg'
 __email__ = 'maciag.artur@gmail.com'
-__version__ = '0.4.3'
+__version__ = '0.4.2'
 __url__ = 'https://github.com/p1c2u/openapi-core'
 __license__ = 'BSD 3-Clause License'
 

--- a/openapi_core/__init__.py
+++ b/openapi_core/__init__.py
@@ -5,7 +5,7 @@ from openapi_core.shortcuts import (
 
 __author__ = 'Artur Maciąg'
 __email__ = 'maciag.artur@gmail.com'
-__version__ = '0.4.2'
+__version__ = '0.4.3'
 __url__ = 'https://github.com/p1c2u/openapi-core'
 __license__ = 'BSD 3-Clause License'
 

--- a/tests/integration/data/v3.0/petstore.yaml
+++ b/tests/integration/data/v3.0/petstore.yaml
@@ -144,8 +144,13 @@ components:
           type: integer
           format: int64
     PetCreate:
-      type: object
       x-model: PetCreate
+      allOf:
+        - $ref: "#/components/schemas/PetCreatePartOne"
+        - $ref: "#/components/schemas/PetCreatePartTwo"
+    PetCreatePartOne:
+      type: object
+      x-model: PetCreatePartOne
       required:
         - name
       properties:
@@ -155,6 +160,10 @@ components:
           $ref: "#/components/schemas/Tag"
         address:
           $ref: "#/components/schemas/Address"
+    PetCreatePartTwo:
+      type: object
+      x-model: PetCreatePartTwo
+      properties:
         position:
           $ref: "#/components/schemas/Position"
         healthy:

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -654,4 +654,4 @@ class TestPetstore(object):
         response_result = response_validator.validate(request, response)
 
         assert response_result.errors == []
-        assert response_result.data == data
+        assert response_result.data == data_json

--- a/tests/integration/test_validators.py
+++ b/tests/integration/test_validators.py
@@ -245,6 +245,7 @@ class TestResponseValidator(object):
             'data': [
                 {
                     'id': 1,
+                    'name': 'Sparky'
                 },
             ],
         }


### PR DESCRIPTION
Currently if valid swagger syntax is used for model composition an
error will be thrown due to the lack of a type property. This was
corrected by making object the default type.

schema_type = schema_deref.get('type', 'object')

I changed the swagger definition to test for this. Now PetCreate is a
composite of PetCreatePartOne and PetCreatePartTwo. However, this
caused `test_post_pets_empty_body` to fail, which turned out to be a
bug in the required properties.

In `_unmarshal_object` the `get_all_properties` method is called to get
all properties from the subschemas. However, this is not done for
required properties, meaning that only top level required properties
will be correctly validated. I have added a
`get_all_required_properties’ to fix this.

This caused `test_get_pets` to fail. In this case the bug allowed an
incorrect test case to be introduced. Pet requires `id`, but it also
requires name because it inherits from PetCreate. I have fixed this
test case by adding the missing required property.

After these changes `test_get_pet_not_found` failed due to a string
formatting error (double quotes vs single quotes). I fixed this by
switching to dictionary comparisons.