### PR TITLE
Integrate Requests library

### DIFF
--- a/openapi_core/wrappers.py
+++ b/openapi_core/wrappers.py
@@ -131,12 +131,8 @@ class RequestsOpenAPIRequest(BaseOpenAPIRequest):
     @property
     def parameters(self):
         return {
-            # List of parameters from path (url string)
             'path': [],
-
-            # MultiDict, список параметров после ? в url
             'query': [],
-
             'headers': self.request.headers,
             'cookies': self.request.cookies,
         }

--- a/openapi_core/wrappers.py
+++ b/openapi_core/wrappers.py
@@ -183,3 +183,21 @@ class FlaskOpenAPIResponse(BaseOpenAPIResponse):
     @property
     def mimetype(self):
         return self.response.mimetype
+
+
+class RequestsOpenAPIResponse(BaseOpenAPIResponse):
+
+    def __init__(self, response):
+        self.response = response
+
+    @property
+    def data(self):
+        return self.response.text
+
+    @property
+    def status_code(self):
+        return self.response.status_code
+
+    @property
+    def mimetype(self):
+        return self.response.headers.get('content-type')

--- a/openapi_core/wrappers.py
+++ b/openapi_core/wrappers.py
@@ -1,7 +1,7 @@
 """OpenAPI core wrappers module"""
 import warnings
 
-from six.moves.urllib.parse import urljoin, urlparse
+from six.moves.urllib.parse import urljoin, urlparse, parse_qsl
 from werkzeug.datastructures import ImmutableMultiDict
 
 
@@ -131,8 +131,8 @@ class RequestsOpenAPIRequest(BaseOpenAPIRequest):
     @property
     def parameters(self):
         return {
-            'path': [],
-            'query': [],
+            'path': self.url.path,
+            'query': ImmutableMultiDict(parse_qsl(self.url.query)),
             'headers': self.request.headers,
             'cookies': self.request.cookies,
         }

--- a/openapi_core/wrappers.py
+++ b/openapi_core/wrappers.py
@@ -139,11 +139,11 @@ class RequestsOpenAPIRequest(BaseOpenAPIRequest):
 
     @property
     def body(self):
-        return ''
+        return self.request.data
 
     @property
     def mimetype(self):
-        return ''
+        return self.request.headers.get('content-type')
 
 
 class BaseOpenAPIResponse(object):

--- a/openapi_core/wrappers.py
+++ b/openapi_core/wrappers.py
@@ -1,7 +1,7 @@
 """OpenAPI core wrappers module"""
 import warnings
 
-from six.moves.urllib.parse import urljoin
+from six.moves.urllib.parse import urljoin, urlparse
 from werkzeug.datastructures import ImmutableMultiDict
 
 
@@ -105,6 +105,49 @@ class FlaskOpenAPIRequest(BaseOpenAPIRequest):
     @property
     def mimetype(self):
         return self.request.mimetype
+
+
+class RequestsOpenAPIRequest(BaseOpenAPIRequest):
+    def __init__(self, request):
+        self.request = request
+        self.url = urlparse(request.url)
+
+    @property
+    def host_url(self):
+        return self.url.scheme + '://' + self.url.netloc
+
+    @property
+    def path(self):
+        return self.url.path
+
+    @property
+    def method(self):
+        return self.request.method.lower()
+
+    @property
+    def path_pattern(self):
+        return self.url.path
+
+    @property
+    def parameters(self):
+        return {
+            # List of parameters from path (url string)
+            'path': [],
+
+            # MultiDict, список параметров после ? в url
+            'query': [],
+
+            'headers': self.request.headers,
+            'cookies': self.request.cookies,
+        }
+
+    @property
+    def body(self):
+        return ''
+
+    @property
+    def mimetype(self):
+        return ''
 
 
 class BaseOpenAPIResponse(object):


### PR DESCRIPTION
Hi!

Thank you for your great lib!

I would like to propose integration with [Requests](http://docs.python-requests.org/), another great python library.

Sometimes I have an API given on another language, and all I have to do is to generate Requests objects based on given opeapi.yaml file and check API Responses. I want to use your lib and thats why I can not or does not want use Flask. 

Usage scenario is something like this:

```python
    req = requests.Request('GET', 'http://88.198.13.202:9051/info')

    openapi_request = RequestsOpenAPIRequest(req)
    validator = RequestValidator(spec)
    result = validator.validate(openapi_request)

    result.raise_for_errors()
    errors = result.errors
    print('Request errors:', errors)

    r = req.prepare()
    s = requests.Session()
    res = s.send(r)

    openapi_response = RequestsOpenAPIResponse(res)
    validator = ResponseValidator(spec)
    result = validator.validate(openapi_request, openapi_response)

    result.raise_for_errors()
    errors = result.errors
    print('Response errors:', errors)
```

Repeat the above for all endpoints in paths in openapi.yaml.