### PR TITLE
If the response is empty list, this is correct answer

### DIFF
--- a/openapi_core/validators.py
+++ b/openapi_core/validators.py
@@ -205,7 +205,7 @@ class ResponseValidator(object):
         return ResponseValidationResult(errors, data, headers)
 
     def _get_raw_data(self, response):
-        if not response.data:
+        if not response.data and type(response.data) != list:
             raise MissingBody("Missing required response data")
 
         return response.data


### PR DESCRIPTION
When API responses with correct empty array, openapi-core generate `MissingBody` exception. Think this case should goes without any errors.
