### PR TITLE
Request headers and cookies parameter parsing fix

### DIFF
--- a/openapi_core/validation/request/models.py
+++ b/openapi_core/validation/request/models.py
@@ -6,7 +6,7 @@ from openapi_core.validation.models import BaseValidationResult
 
 class RequestParameters(dict):
 
-    valid_locations = ['path', 'query', 'headers', 'cookies']
+    valid_locations = ['path', 'query', 'header', 'cookie']
 
     def __getitem__(self, location):
         self.validate_location(location)


### PR DESCRIPTION
[OpenAPI 3 spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#parameterObject) uses 'header' and 'cookie' as parameter location.