### PR TITLE
Makes it possible to access API examples

### DIFF
--- a/openapi_core/schema/media_types/generators.py
+++ b/openapi_core/schema/media_types/generators.py
@@ -14,8 +14,15 @@ class MediaTypeGenerator(object):
         for mimetype, media_type in iteritems(content):
             schema_spec = media_type.get('schema')
 
+            example_spec = media_type.get('example')
+            example_type = type(example_spec)
+            if example_type is dict:
+                example = self.dereferencer.dereference(example_spec)
+            else:
+                example = example_spec
+
             schema = None
             if schema_spec:
                 schema, _ = self.schemas_registry.get_or_create(schema_spec)
 
-            yield mimetype, MediaType(mimetype, schema)
+            yield mimetype, MediaType(mimetype, schema=schema, example=example)

--- a/openapi_core/schema/media_types/models.py
+++ b/openapi_core/schema/media_types/models.py
@@ -15,9 +15,10 @@ MEDIA_TYPE_DESERIALIZERS = {
 class MediaType(object):
     """Represents an OpenAPI MediaType."""
 
-    def __init__(self, mimetype, schema=None):
+    def __init__(self, mimetype, schema=None, example=None):
         self.mimetype = mimetype
         self.schema = schema
+        self.example = example
 
     def get_deserializer_mapping(self):
         mapping = MEDIA_TYPE_DESERIALIZERS.copy()

--- a/tests/integration/data/v3.0/petstore.yaml
+++ b/tests/integration/data/v3.0/petstore.yaml
@@ -66,7 +66,7 @@ paths:
               schema:
                 type: string
           content:
-            application/json:    
+            application/json:
               schema:
                 $ref: "#/components/schemas/PetsData"
     post:
@@ -80,6 +80,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/PetCreate'
+            example:
+              name: "Pet"
+              wings: []
       responses:
         '201':
           description: Null response
@@ -106,6 +109,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/PetData"
+              example: |
+                {
+                  "data": []
+                }
             image/*:
               schema:
                 type: string
@@ -125,6 +132,9 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TagList"
+              example:
+                - dogs
+                - cats
         default:
           $ref: "#/components/responses/ErrorResponse"
     post:

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -102,6 +102,10 @@ class TestPetstore(object):
                         assert media_type.mimetype == mimetype
 
                         content_spec = response_spec['content'][mimetype]
+
+                        example_spec = content_spec.get('example')
+                        assert media_type.example == example_spec
+
                         schema_spec = content_spec.get('schema')
                         assert bool(schema_spec) == bool(media_type.schema)
 


### PR DESCRIPTION
Would be nice to be able to access the API examples defined in the specification. Not all examples access are implemented in this PR, but it's a first step. The next work would be to make the library parse `examples` and making it also exposed through the `MediaType` model.