### PR TITLE
Expose tags in Operation object

### DIFF
--- a/openapi_core/schema/operations/generators.py
+++ b/openapi_core/schema/operations/generators.py
@@ -31,6 +31,7 @@ class OperationsGenerator(object):
             parameters = self.parameters_generator.generate_from_list(
                 parameters_list)
             operation_id = operation_deref.get('operationId')
+            tags_list = operation_deref.get('tags', [])
 
             request_body = None
             if 'requestBody' in operation_deref:
@@ -43,7 +44,7 @@ class OperationsGenerator(object):
                 Operation(
                     http_method, path_name, responses, list(parameters),
                     request_body=request_body, deprecated=deprecated,
-                    operation_id=operation_id,
+                    operation_id=operation_id, tags=list(tags_list)
                 ),
             )
 

--- a/openapi_core/schema/operations/models.py
+++ b/openapi_core/schema/operations/models.py
@@ -8,7 +8,7 @@ class Operation(object):
 
     def __init__(
             self, http_method, path_name, responses, parameters,
-            request_body=None, deprecated=False, operation_id=None):
+            request_body=None, deprecated=False, operation_id=None, tags=None):
         self.http_method = http_method
         self.path_name = path_name
         self.responses = dict(responses)
@@ -16,6 +16,7 @@ class Operation(object):
         self.request_body = request_body
         self.deprecated = deprecated
         self.operation_id = operation_id
+        self.tags = tags
 
     def __getitem__(self, name):
         return self.parameters[name]

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -73,12 +73,13 @@ class TestPetstore(object):
             assert path.name == path_name
 
             for http_method, operation in iteritems(path.operations):
+                operation_spec = spec_dict['paths'][path_name][http_method]
+
                 assert type(operation) == Operation
                 assert operation.path_name == path_name
                 assert operation.http_method == http_method
                 assert operation.operation_id is not None
-
-                operation_spec = spec_dict['paths'][path_name][http_method]
+                assert operation.tags == operation_spec['tags']
 
                 responses_spec = operation_spec.get('responses')
 


### PR DESCRIPTION
There's a need to access endpoint tags in parsed spec. Adding this feature here.