### PR TITLE
openapi 3.0 defines date-time format to be rfc3339

### DIFF
--- a/openapi_core/schema/schemas/util.py
+++ b/openapi_core/schema/schemas/util.py
@@ -3,6 +3,7 @@ import datetime
 from distutils.util import strtobool
 from json import dumps
 from six import string_types
+import strict_rfc3339
 
 
 def forcebool(val):
@@ -21,4 +22,5 @@ def format_date(value):
 
 
 def format_datetime(value):
-    return datetime.datetime.strptime(value, '%Y-%m-%dT%H:%M:%S')
+    timestamp = strict_rfc3339.rfc3339_to_timestamp(value)
+    return datetime.datetime.fromtimestamp(timestamp)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openapi-spec-validator
 six
 lazy-object-proxy
+strict_rfc3339

--- a/requirements_2.7.txt
+++ b/requirements_2.7.txt
@@ -4,3 +4,4 @@ lazy-object-proxy
 backports.functools-lru-cache
 backports.functools-partialmethod
 enum34
+strict_rfc3339

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ class PyTest(TestCommand):
             '--cov', 'openapi_core',
             '--cov-report', 'term-missing',
             '--cov-report', 'xml:reports/coverage.xml',
+            'tests',
         ]
         self.test_suite = True
 

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -81,11 +81,11 @@ class TestSchemaUnmarshal(object):
 
     def test_string_format_datetime(self):
         schema = Schema('string', schema_format='date-time')
-        value = '2018-01-02T00:00:00'
+        value = '2018-01-02T00:00:00Z'
 
         result = schema.unmarshal(value)
 
-        assert result == datetime.datetime(2018, 1, 2, 0, 0, 0)
+        assert result == datetime.datetime(2018, 1, 2, 0, 0)
 
     @pytest.mark.xfail(reason="No custom formats support atm")
     def test_string_format_custom(self):


### PR DESCRIPTION
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#data-types

Note: `jsonschema` uses the same library if it's installed (and otherwise doesn't validate `date-time`).

cc @p1c2u 