### PR TITLE
fix test for non utc systems.

### DIFF
--- a/openapi_core/schema/schemas/util.py
+++ b/openapi_core/schema/schemas/util.py
@@ -23,4 +23,4 @@ def format_date(value):
 
 def format_datetime(value):
     timestamp = strict_rfc3339.rfc3339_to_timestamp(value)
-    return datetime.datetime.fromtimestamp(timestamp)
+    return datetime.datetime.utcfromtimestamp(timestamp)


### PR DESCRIPTION
`strict_rfc3339.rfc3339_to_timestamp()` is tz aware
`datetime.datetime.fromtimestamp` is not

this causes  the test `test_string_format_datetime` to fail on
system that are not on utc