### PR TITLE
Accepting uuid string format and validating accordingly.

### DIFF
--- a/openapi_core/schema/schemas/enums.py
+++ b/openapi_core/schema/schemas/enums.py
@@ -25,3 +25,4 @@ class SchemaFormat(Enum):
     DATE = 'date'
     DATETIME = 'date-time'
     PASSWORD = 'password'
+    UUID = 'uuid'

--- a/openapi_core/schema/schemas/models.py
+++ b/openapi_core/schema/schemas/models.py
@@ -8,6 +8,7 @@ import re
 import warnings
 
 from six import iteritems, integer_types, binary_type, text_type
+from uuid import UUID
 
 from openapi_core.extensions.models.factories import ModelFactory
 from openapi_core.schema.schemas.enums import SchemaFormat, SchemaType
@@ -46,6 +47,7 @@ class Schema(object):
         SchemaFormat.DATE: Format(format_date, TypeValidator(date, exclude=datetime)),
         SchemaFormat.DATETIME: Format(format_datetime, TypeValidator(datetime)),
         SchemaFormat.BINARY: Format(binary_type, TypeValidator(binary_type)),
+        SchemaFormat.UUID: Format(UUID, TypeValidator(UUID)),
     }
 
     TYPE_VALIDATOR_CALLABLE_GETTER = {
@@ -54,7 +56,7 @@ class Schema(object):
         SchemaType.INTEGER: TypeValidator(integer_types, exclude=bool),
         SchemaType.NUMBER: TypeValidator(integer_types, float, exclude=bool),
         SchemaType.STRING: TypeValidator(
-            text_type, date, datetime, binary_type),
+            text_type, date, datetime, binary_type, UUID),
         SchemaType.ARRAY: TypeValidator(list, tuple),
         SchemaType.OBJECT: AttributeValidator('__dict__'),
     }

--- a/tests/integration/data/v3.0/petstore.yaml
+++ b/tests/integration/data/v3.0/petstore.yaml
@@ -317,6 +317,9 @@ components:
           required:
             - rootCause
           properties:
+            correlationId:
+              type: string
+              format: uuid
             rootCause:
               type: string
             suberror:

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from uuid import UUID
 from six import iteritems
 
 from openapi_core.extensions.models.models import BaseModel
@@ -1154,11 +1155,13 @@ class TestPetstore(object):
 
         code = 400
         message = 'Bad request'
+        correlationId = UUID('a8098c1a-f86e-11da-bd1a-00112444be1e')
         rootCause = 'Tag already exist'
         additionalinfo = 'Tag Dog already exist'
         data_json = {
             'code': code,
             'message': message,
+            'correlationId': str(correlationId),
             'rootCause': rootCause,
             'additionalinfo': additionalinfo,
         }
@@ -1171,5 +1174,6 @@ class TestPetstore(object):
         assert isinstance(response_result.data, BaseModel)
         assert response_result.data.code == code
         assert response_result.data.message == message
+        assert response_result.data.correlationId == correlationId
         assert response_result.data.rootCause == rootCause
         assert response_result.data.additionalinfo == additionalinfo

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -1,4 +1,5 @@
 import datetime
+import uuid
 
 import mock
 import pytest
@@ -415,6 +416,26 @@ class TestSchemaValidate(object):
         result = schema.validate(value)
 
         assert result == value
+
+    @pytest.mark.parametrize('value', [
+        uuid.UUID('{12345678-1234-5678-1234-567812345678}'),
+    ])
+    def test_string_format_uuid(self, value):
+        schema = Schema('string', schema_format='uuid')
+
+        result = schema.validate(value)
+
+        assert result == value
+
+    @pytest.mark.parametrize('value', [
+        b('true'), u('true'), False, 1, 3.14, [1, 3],
+        datetime.date(2018, 1, 2), datetime.datetime(2018, 1, 2, 23, 59, 59),
+    ])
+    def test_string_format_uuid_invalid(self, value):
+        schema = Schema('string', schema_format='uuid')
+
+        with pytest.raises(InvalidSchemaValue):
+            schema.validate(value)
 
     @pytest.mark.parametrize('value', [
         b('true'), u('true'), False, 1, 3.14, [1, 3],


### PR DESCRIPTION
This introduces the compatibility with uuid formatted strings. Although it's not a predefined format in the standard, it's predicted as a possible custom format, so it makes sense to implement it since Python supports this as a type in the stdlib.