### PR TITLE
Properly formatting UUID if value to be unmarshalled is already a UUID.

### DIFF
--- a/openapi_core/schema/schemas/models.py
+++ b/openapi_core/schema/schemas/models.py
@@ -20,6 +20,7 @@ from openapi_core.schema.schemas.exceptions import (
 )
 from openapi_core.schema.schemas.util import (
     forcebool, format_date, format_datetime,
+    format_uuid,
 )
 from openapi_core.schema.schemas.validators import (
     TypeValidator, AttributeValidator,
@@ -49,7 +50,7 @@ class Schema(object):
             format_date, TypeValidator(date, exclude=datetime)),
         SchemaFormat.DATETIME: Format(format_datetime, TypeValidator(datetime)),
         SchemaFormat.BINARY: Format(binary_type, TypeValidator(binary_type)),
-        SchemaFormat.UUID: Format(UUID, TypeValidator(UUID)),
+        SchemaFormat.UUID: Format(format_uuid, TypeValidator(UUID)),
         SchemaFormat.BYTE: Format(b64decode, TypeValidator(binary_type)),
     }
 

--- a/openapi_core/schema/schemas/util.py
+++ b/openapi_core/schema/schemas/util.py
@@ -4,6 +4,7 @@ from distutils.util import strtobool
 from json import dumps
 from six import string_types
 import strict_rfc3339
+from uuid import UUID
 
 
 def forcebool(val):
@@ -24,3 +25,9 @@ def format_date(value):
 def format_datetime(value):
     timestamp = strict_rfc3339.rfc3339_to_timestamp(value)
     return datetime.datetime.utcfromtimestamp(timestamp)
+
+
+def format_uuid(value):
+    if isinstance(value, UUID):
+        return value
+    return UUID(value)

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -50,7 +50,7 @@ class TestSchemaUnmarshal(object):
 
         assert result == value
 
-    def test_string_valid_uuid_str(self):
+    def test_string_format_uuid_valid(self):
         schema = Schema(SchemaType.STRING, schema_format=SchemaFormat.UUID)
         value = str(uuid.uuid4())
 
@@ -58,11 +58,11 @@ class TestSchemaUnmarshal(object):
 
         assert result == uuid.UUID(value)
 
-    def test_string_valid_uuid(self):
+    def test_string_format_uuid_valid(self):
         schema = Schema(SchemaType.STRING, schema_format=SchemaFormat.UUID)
         value = uuid.uuid4()
 
-        result = schema.unmarshal(value)
+        result = schema.unmarshal(value, strict=False)
 
         assert result == value
 

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -5,6 +5,7 @@ import mock
 import pytest
 
 from openapi_core.extensions.models.models import Model
+from openapi_core.schema.schemas.enums import SchemaFormat, SchemaType
 from openapi_core.schema.schemas.exceptions import (
     InvalidSchemaValue, MultipleOneOfSchema, NoOneOfSchema, OpenAPISchemaError,
 )
@@ -43,6 +44,22 @@ class TestSchemaUnmarshal(object):
     def test_string_valid(self):
         schema = Schema('string')
         value = 'test'
+
+        result = schema.unmarshal(value)
+
+        assert result == value
+
+    def test_string_valid_uuid_str(self):
+        schema = Schema(SchemaType.STRING, schema_format=SchemaFormat.UUID)
+        value = str(uuid.uuid4())
+
+        result = schema.unmarshal(value)
+
+        assert result == uuid.UUID(value)
+
+    def test_string_valid_uuid(self):
+        schema = Schema(SchemaType.STRING, schema_format=SchemaFormat.UUID)
+        value = uuid.uuid4()
 
         result = schema.unmarshal(value)
 

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -58,7 +58,7 @@ class TestSchemaUnmarshal(object):
 
         assert result == uuid.UUID(value)
 
-    def test_string_format_uuid_valid(self):
+    def test_string_format_uuid_uuid_quirks_valid(self):
         schema = Schema(SchemaType.STRING, schema_format=SchemaFormat.UUID)
         value = uuid.uuid4()
 


### PR DESCRIPTION
Before this change, if a UUID instance got received as value in the Schema, it was breaking the unmarshal because UUID instances can't be used as values to instantiate other UUIDs.

An example of where this might happen is if you define a parameter with uuid format in a spec for a Flask app, and then use the `<uuid>` converter in the route path (for the Flask router), which converts the parameter to a UUID instance before it reaches the unmarshalling step.