### PR TITLE
Add support for one-of with any type

### DIFF
--- a/openapi_core/schema/schemas/util.py
+++ b/openapi_core/schema/schemas/util.py
@@ -1,16 +1,8 @@
 """OpenAPI core schemas util module"""
 import datetime
-from distutils.util import strtobool
 from json import dumps
 from six import string_types, text_type
 import strict_rfc3339
-
-
-def forcebool(val):
-    if isinstance(val, string_types):
-        val = strtobool(val)
-
-    return bool(val)
 
 
 def strictbool(val):
@@ -23,6 +15,7 @@ def strictstr(val):
     if not isinstance(val, string_types):
         raise TypeError('expected text, got {type}'.format(type=type(val)))
     return text_type(val)
+
 
 def dicthash(d):
     return hash(dumps(d, sort_keys=True))

--- a/openapi_core/schema/schemas/util.py
+++ b/openapi_core/schema/schemas/util.py
@@ -2,7 +2,7 @@
 import datetime
 from distutils.util import strtobool
 from json import dumps
-from six import string_types
+from six import string_types, text_type
 import strict_rfc3339
 
 
@@ -12,6 +12,17 @@ def forcebool(val):
 
     return bool(val)
 
+
+def strictbool(val):
+    if not isinstance(val, bool):
+        raise TypeError('expected bool, got {type}'.format(type=type(val)))
+    return val
+
+
+def strictstr(val):
+    if not isinstance(val, text_type):
+        raise TypeError('expected text, got {type}'.format(type=type(val)))
+    return val
 
 def dicthash(d):
     return hash(dumps(d, sort_keys=True))

--- a/openapi_core/schema/schemas/util.py
+++ b/openapi_core/schema/schemas/util.py
@@ -20,9 +20,9 @@ def strictbool(val):
 
 
 def strictstr(val):
-    if not isinstance(val, text_type):
+    if not isinstance(val, string_types):
         raise TypeError('expected text, got {type}'.format(type=type(val)))
-    return val
+    return text_type(val)
 
 def dicthash(d):
     return hash(dumps(d, sort_keys=True))

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from datetime import datetime
 from base64 import b64encode
 from uuid import UUID
 from six import iteritems
@@ -528,6 +529,7 @@ class TestPetstore(object):
         assert body.address.city == pet_city
         assert body.healthy == pet_healthy
 
+    @pytest.mark.xfail(reason='truthy values should not cast to bool')
     def test_post_cats_boolean_string(self, spec, spec_dict):
         host_url = 'http://petstore.swagger.io/v1'
         path_pattern = '/v1/pets'
@@ -1111,7 +1113,7 @@ class TestPetstore(object):
 
         assert parameters == {}
         assert isinstance(body, BaseModel)
-        assert body.created == created
+        assert body.created == datetime(2016, 4, 16, 16, 6, 5)
         assert body.name == pet_name
 
         code = 400

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -18,9 +18,6 @@ from openapi_core.schema.parameters.models import Parameter
 from openapi_core.schema.paths.models import Path
 from openapi_core.schema.request_bodies.models import RequestBody
 from openapi_core.schema.responses.models import Response
-from openapi_core.schema.schemas.exceptions import (
-    NoValidSchema,
-)
 from openapi_core.schema.schemas.models import Schema
 from openapi_core.schema.servers.exceptions import InvalidServer
 from openapi_core.schema.servers.models import Server, ServerVariable

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -1157,7 +1157,7 @@ class TestPetstore(object):
         )
 
         parameters = request.get_parameters(spec)
-        with pytest.raises(NoValidSchema):
+        with pytest.raises(InvalidMediaTypeValue):
             request.get_body(spec)
 
         assert parameters == {}

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -173,6 +173,7 @@ class TestSchemaUnmarshal(object):
 
     def test_schema_any_one_of(self):
         schema = Schema(one_of=[
+            Schema('string'),
             Schema('array', items=Schema('string')),
         ])
         assert schema.unmarshal(['hello']) == ['hello']
@@ -193,6 +194,9 @@ class TestSchemaUnmarshal(object):
         with pytest.raises(NoOneOfSchema):
             schema.unmarshal({})
 
+    def test_schema_any(self):
+        schema = Schema()
+        assert schema.unmarshal('string') == 'string'
 
 class TestSchemaValidate(object):
 

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -171,6 +171,28 @@ class TestSchemaUnmarshal(object):
         with pytest.raises(InvalidSchemaValue):
             schema.unmarshal(value)
 
+    def test_schema_any_one_of(self):
+        schema = Schema(one_of=[
+            Schema('array', items=Schema('string')),
+        ])
+        assert schema.unmarshal(['hello']) == ['hello']
+
+    def test_schema_any_one_of_mutiple(self):
+        schema = Schema(one_of=[
+            Schema('array', items=Schema('string')),
+            Schema('array', items=Schema('number')),
+        ])
+        with pytest.raises(MultipleOneOfSchema):
+            schema.unmarshal([])
+
+    def test_schema_any_one_of_no_valid(self):
+        schema = Schema(one_of=[
+            Schema('array', items=Schema('string')),
+            Schema('array', items=Schema('number')),
+        ])
+        with pytest.raises(NoOneOfSchema):
+            schema.unmarshal({})
+
 
 class TestSchemaValidate(object):
 

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -198,6 +198,7 @@ class TestSchemaUnmarshal(object):
         schema = Schema()
         assert schema.unmarshal('string') == 'string'
 
+
 class TestSchemaValidate(object):
 
     @pytest.mark.parametrize('schema_type', [


### PR DESCRIPTION
This pull requests adds support for various cases of oneOf in combination with a SchemaType.ANY schema that currently fail to unmarshal correctly, for example consider the following schema...

```yaml
Polymorphic:
  oneOf:
    Values:
      type:  array
      items:
        type: string
    Value:
      type: string
```

Currently trying to unmarshal the value ``["hello"]`` will return ``True``, I'm sure there are plenty of other cases that will fail to unmarshal correctly because the casting is not strict enough.

There is perhaps a controversial change in this PR, namely making conversion to bool strict, since I see there was a test added specifically to test this behaviour. However the open api 3.0 [spec](https://swagger.io/docs/specification/data-models/data-types/#boolean) states:

> truthy and falsy values such as "``true``", "", 0 or ``null`` are not considered boolean values. 

So I would actually expect truthy strings not to be castable to bool.

Please could you review these changes and let me know if there is anything I need to change? Thanks in advance!
  