### PR TITLE
String byte format fix

### DIFF
--- a/openapi_core/schema/schemas/models.py
+++ b/openapi_core/schema/schemas/models.py
@@ -19,8 +19,7 @@ from openapi_core.schema.schemas.exceptions import (
     UndefinedItemsSchema, InvalidCustomFormatSchemaValue, InvalidSchemaProperty,
 )
 from openapi_core.schema.schemas.util import (
-    forcebool, format_date, format_datetime,
-    format_uuid,
+    forcebool, format_date, format_datetime, format_byte, format_uuid,
 )
 from openapi_core.schema.schemas.validators import (
     TypeValidator, AttributeValidator,
@@ -48,7 +47,7 @@ class Schema(object):
         SchemaFormat.DATETIME: Format(format_datetime, TypeValidator(datetime)),
         SchemaFormat.BINARY: Format(binary_type, TypeValidator(binary_type)),
         SchemaFormat.UUID: Format(format_uuid, TypeValidator(UUID)),
-        SchemaFormat.BYTE: Format(b64decode, TypeValidator(binary_type)),
+        SchemaFormat.BYTE: Format(format_byte, TypeValidator(text_type)),
     }
 
     TYPE_VALIDATOR_CALLABLE_GETTER = {

--- a/openapi_core/schema/schemas/util.py
+++ b/openapi_core/schema/schemas/util.py
@@ -1,8 +1,9 @@
 """OpenAPI core schemas util module"""
+from base64 import b64decode
 import datetime
 from distutils.util import strtobool
 from json import dumps
-from six import string_types
+from six import string_types, text_type
 import strict_rfc3339
 from uuid import UUID
 
@@ -31,3 +32,7 @@ def format_uuid(value):
     if isinstance(value, UUID):
         return value
     return UUID(value)
+
+
+def format_byte(value, encoding='utf8'):
+    return text_type(b64decode(value), encoding)

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -2,7 +2,7 @@ import json
 import pytest
 from base64 import b64encode
 from uuid import UUID
-from six import iteritems
+from six import iteritems, text_type
 
 from openapi_core.extensions.models.models import BaseModel
 from openapi_core.schema.media_types.exceptions import (
@@ -32,11 +32,13 @@ from openapi_core.wrappers.mock import MockRequest, MockResponse
 
 class TestPetstore(object):
 
-    api_key = b'12345'
+    api_key = '12345'
 
     @property
     def api_key_encoded(self):
-        return b64encode(self.api_key)
+        api_key_bytes = self.api_key.encode('utf8')
+        api_key_bytes_enc = b64encode(api_key_bytes)
+        return text_type(api_key_bytes_enc, 'utf8')
 
     @pytest.fixture
     def spec_dict(self, factory):

--- a/tests/integration/test_validators.py
+++ b/tests/integration/test_validators.py
@@ -1,6 +1,7 @@
 from base64 import b64encode
 import json
 import pytest
+from six import text_type
 
 from openapi_core.schema.media_types.exceptions import (
     InvalidContentType, InvalidMediaTypeValue,
@@ -23,11 +24,13 @@ class TestRequestValidator(object):
 
     host_url = 'http://petstore.swagger.io'
 
-    api_key = b'12345'
+    api_key = '12345'
 
     @property
     def api_key_encoded(self):
-        return b64encode(self.api_key)
+        api_key_bytes = self.api_key.encode('utf8')
+        api_key_bytes_enc = b64encode(api_key_bytes)
+        return text_type(api_key_bytes_enc, 'utf8')
 
     @pytest.fixture
     def spec_dict(self, factory):

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -577,7 +577,7 @@ class TestSchemaValidate(object):
         assert result == value
 
     @pytest.mark.parametrize('value', [
-        u('tsssst'), u('dGVzdA=='),
+        b('tsssst'), b('dGVzdA=='),
     ])
     def test_string_format_byte_invalid(self, value):
         schema = Schema('string', schema_format='byte')
@@ -586,7 +586,7 @@ class TestSchemaValidate(object):
             schema.validate(value)
 
     @pytest.mark.parametrize('value', [
-        b('tsssst'), b('dGVzdA=='),
+        u('tsssst'), u('dGVzdA=='),
     ])
     def test_string_format_byte(self, value):
         schema = Schema('string', schema_format='byte')


### PR DESCRIPTION
Previously `byte` format had to be binary type on input and output of unmarshalling. Now it should be text type.