### PR TITLE
Add additional meta data to schema and errors

### DIFF
--- a/openapi_core/schema/schemas/exceptions.py
+++ b/openapi_core/schema/schemas/exceptions.py
@@ -3,8 +3,9 @@ from openapi_core.schema.exceptions import OpenAPIMappingError
 import attr
 
 
+@attr.s
 class OpenAPISchemaError(OpenAPIMappingError):
-    pass
+    schema = attr.ib()
 
 
 @attr.s
@@ -77,3 +78,19 @@ class MultipleOneOfSchema(OpenAPISchemaError):
 
     def __str__(self):
         return "Exactly one schema type {0} should be valid, more than one found".format(self.type)
+
+
+@attr.s
+class InvalidSchema(OpenAPISchemaError):
+    msg = attr.ib()
+
+    def __str__(self):
+        return self.msg
+
+
+@attr.s
+class InvalidFormat(OpenAPISchemaError):
+    msg = attr.ib()
+
+    def __str__(self):
+        return self.msg

--- a/openapi_core/schema/schemas/factories.py
+++ b/openapi_core/schema/schemas/factories.py
@@ -13,7 +13,7 @@ class SchemaFactory(object):
     def __init__(self, dereferencer):
         self.dereferencer = dereferencer
 
-    def create(self, schema_spec):
+    def create(self, schema_spec, schema_name=''):
         schema_deref = self.dereferencer.dereference(schema_spec)
 
         schema_type = schema_deref.get('type', None)
@@ -75,6 +75,7 @@ class SchemaFactory(object):
             exclusive_maximum=exclusive_maximum,
             exclusive_minimum=exclusive_minimum,
             min_properties=min_properties, max_properties=max_properties,
+            schema_name=schema_name, schema_deref=schema_deref,
         )
 
     @property

--- a/openapi_core/schema/schemas/generators.py
+++ b/openapi_core/schema/schemas/generators.py
@@ -16,5 +16,5 @@ class SchemasGenerator(object):
         schemas_deref = self.dereferencer.dereference(schemas_spec)
 
         for schema_name, schema_spec in iteritems(schemas_deref):
-            schema, _ = self.schemas_registry.get_or_create(schema_spec)
+            schema, _ = self.schemas_registry.get_or_create(schema_spec, schema_name)
             yield schema_name, schema

--- a/openapi_core/schema/schemas/registries.py
+++ b/openapi_core/schema/schemas/registries.py
@@ -15,7 +15,7 @@ class SchemaRegistry(SchemaFactory):
         super(SchemaRegistry, self).__init__(dereferencer)
         self._schemas = {}
 
-    def get_or_create(self, schema_spec):
+    def get_or_create(self, schema_spec, schema_name=''):
         schema_hash = dicthash(schema_spec)
         schema_deref = self.dereferencer.dereference(schema_spec)
 
@@ -23,9 +23,9 @@ class SchemaRegistry(SchemaFactory):
             return self._schemas[schema_hash], False
 
         if '$ref' in schema_spec:
-            schema = Proxy(lambda: self.create(schema_deref))
+            schema = Proxy(lambda: self.create(schema_deref, schema_name))
         else:
-            schema = self.create(schema_deref)
+            schema = self.create(schema_deref, schema_name)
 
         self._schemas[schema_hash] = schema
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,3 +3,4 @@ pytest==3.5.0
 pytest-flake8
 pytest-cov==2.5.1
 flask
+ruamel.yaml==0.15.89


### PR DESCRIPTION
This pull request adds additional information in the schema object (name and dered) and additional stores a reference in schema errors to the schema that caused the error. This gives us the ability to provide additional context when an error occurs, for example if the schema is named then the name of the schema, or if the yaml is parsed with ruamel.yaml we can show the line and column number that generated the error.