### PR TITLE
Raw value type strict validation

### DIFF
--- a/openapi_core/schema/parameters/models.py
+++ b/openapi_core/schema/parameters/models.py
@@ -109,7 +109,11 @@ class Parameter(object):
             raise InvalidParameterValue(self.name, exc)
 
         try:
-            unmarshalled = self.schema.unmarshal(deserialized, custom_formatters=custom_formatters)
+            unmarshalled = self.schema.unmarshal(
+                deserialized,
+                custom_formatters=custom_formatters,
+                strict=False,
+            )
         except OpenAPISchemaError as exc:
             raise InvalidParameterValue(self.name, exc)
 

--- a/tests/integration/data/v3.0/petstore.yaml
+++ b/tests/integration/data/v3.0/petstore.yaml
@@ -59,16 +59,7 @@ paths:
           explode: false
       responses:
         '200':
-          description: An paged array of pets
-          headers:
-            x-next:
-              description: A link to the next page of responses
-              schema:
-                type: string
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PetsData"
+          $ref: "#/components/responses/PetsResponse"
     post:
       summary: Create a pet
       operationId: createPets
@@ -327,9 +318,20 @@ components:
       additionalProperties:
         type: string
   responses:
-      ErrorResponse:
-        description: unexpected error
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ExtendedError"
+    ErrorResponse:
+      description: unexpected error
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ExtendedError"
+    PetsResponse:
+      description: An paged array of pets
+      headers:
+        x-next:
+          description: A link to the next page of responses
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/PetsData"

--- a/tests/integration/test_validators.py
+++ b/tests/integration/test_validators.py
@@ -155,7 +155,7 @@ class TestRequestValidator(object):
         data_json = {
             'name': pet_name,
             'tag': pet_tag,
-            'position': '2',
+            'position': 2,
             'address': {
                 'street': pet_street,
                 'city': pet_city,

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -48,6 +48,13 @@ class TestSchemaUnmarshal(object):
 
         assert result == value
 
+    def test_string_float_invalid(self):
+        schema = Schema('string')
+        value = 1.23
+
+        with pytest.raises(InvalidSchemaValue):
+            schema.unmarshal(value)
+
     def test_string_none(self):
         schema = Schema('string')
         value = None
@@ -117,7 +124,7 @@ class TestSchemaUnmarshal(object):
         value = 'x'
 
         with mock.patch.dict(
-            Schema.STRING_FORMAT_CAST_CALLABLE_GETTER,
+            Schema.STRING_FORMAT_CALLABLE_GETTER,
             {custom_format: mock.Mock(side_effect=ValueError())},
         ), pytest.raises(
             InvalidSchemaValue, message='Failed to format value'
@@ -126,11 +133,18 @@ class TestSchemaUnmarshal(object):
 
     def test_integer_valid(self):
         schema = Schema('integer')
-        value = '123'
+        value = 123
 
         result = schema.unmarshal(value)
 
         assert result == int(value)
+
+    def test_integer_string_invalid(self):
+        schema = Schema('integer')
+        value = '123'
+
+        with pytest.raises(InvalidSchemaValue):
+            schema.unmarshal(value)
 
     def test_integer_enum_invalid(self):
         schema = Schema('integer', enum=[1, 2, 3])
@@ -141,11 +155,18 @@ class TestSchemaUnmarshal(object):
 
     def test_integer_enum(self):
         schema = Schema('integer', enum=[1, 2, 3])
-        value = '2'
+        value = 2
 
         result = schema.unmarshal(value)
 
         assert result == int(value)
+
+    def test_integer_enum_string_invalid(self):
+        schema = Schema('integer', enum=[1, 2, 3])
+        value = '2'
+
+        with pytest.raises(InvalidSchemaValue):
+            schema.unmarshal(value)
 
     def test_integer_default(self):
         default_value = '123'
@@ -167,6 +188,65 @@ class TestSchemaUnmarshal(object):
     def test_integer_invalid(self):
         schema = Schema('integer')
         value = 'abc'
+
+        with pytest.raises(InvalidSchemaValue):
+            schema.unmarshal(value)
+
+    def test_array_valid(self):
+        schema = Schema('array', items=Schema('integer'))
+        value = [1, 2, 3]
+
+        result = schema.unmarshal(value)
+
+        assert result == value
+
+    def test_array_of_string_string_invalid(self):
+        schema = Schema('array', items=Schema('string'))
+        value = '123'
+
+        with pytest.raises(InvalidSchemaValue):
+            schema.unmarshal(value)
+
+    def test_array_of_integer_string_invalid(self):
+        schema = Schema('array', items=Schema('integer'))
+        value = '123'
+
+        with pytest.raises(InvalidSchemaValue):
+            schema.unmarshal(value)
+
+    def test_boolean_valid(self):
+        schema = Schema('boolean')
+        value = True
+
+        result = schema.unmarshal(value)
+
+        assert result == value
+
+    def test_boolean_string_invalid(self):
+        schema = Schema('boolean')
+        value = 'True'
+
+        with pytest.raises(InvalidSchemaValue):
+            schema.unmarshal(value)
+
+    def test_number_valid(self):
+        schema = Schema('number')
+        value = 1.23
+
+        result = schema.unmarshal(value)
+
+        assert result == value
+
+    def test_number_string_invalid(self):
+        schema = Schema('number')
+        value = '1.23'
+
+        with pytest.raises(InvalidSchemaValue):
+            schema.unmarshal(value)
+
+    def test_number_int_invalid(self):
+        schema = Schema('number')
+        value = 1
 
         with pytest.raises(InvalidSchemaValue):
             schema.unmarshal(value)
@@ -759,6 +839,68 @@ class TestSchemaValidate(object):
             'array',
             items=Schema('number'),
             unique_items=True,
+        )
+
+        with pytest.raises(Exception):
+            schema.validate(value)
+
+    @pytest.mark.parametrize('value', [
+        Model({
+            'someint': 123,
+        }),
+        Model({
+            'somestr': u('content'),
+        }),
+        Model({
+            'somestr': u('content'),
+            'someint': 123,
+        }),
+    ])
+    def test_object_with_properties(self, value):
+        schema = Schema(
+            'object',
+            properties={
+                'somestr': Schema('string'),
+                'someint': Schema('integer'),
+            },
+        )
+
+        result = schema.validate(value)
+
+        assert result == value
+
+    @pytest.mark.parametrize('value', [
+        Model({
+            'somestr': Model(),
+            'someint': 123,
+        }),
+        Model({
+            'somestr': {},
+            'someint': 123,
+        }),
+        Model({
+            'somestr': [
+                'content1', 'content2'
+            ],
+            'someint': 123,
+        }),
+        Model({
+            'somestr': 123,
+            'someint': 123,
+        }),
+        Model({
+            'somestr': 'content',
+            'someint': 123,
+            'not_in_scheme_prop': 123,
+        }),
+    ])
+    def test_object_with_invalid_properties(self, value):
+        schema = Schema(
+            'object',
+            properties={
+                'somestr': Schema('string'),
+                'someint': Schema('integer'),
+            },
         )
 
         with pytest.raises(Exception):


### PR DESCRIPTION
Strict validation of raw value type.
Enabled for media type only. Parameters are disabled for now (backward compatibility). Parameters type strict validation should be enabled by default in version 1.0.

Fixes #105