### PR TITLE
Add support for `password` string format

### DIFF
--- a/openapi_core/schema/schemas/models.py
+++ b/openapi_core/schema/schemas/models.py
@@ -42,6 +42,7 @@ class Schema(object):
 
     STRING_FORMAT_CALLABLE_GETTER = {
         SchemaFormat.NONE: Format(text_type, TypeValidator(text_type)),
+        SchemaFormat.PASSWORD: Format(text_type, TypeValidator(text_type)),
         SchemaFormat.DATE: Format(
             format_date, TypeValidator(date, exclude=datetime)),
         SchemaFormat.DATETIME: Format(format_datetime, TypeValidator(datetime)),

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -66,6 +66,14 @@ class TestSchemaUnmarshal(object):
 
         assert result == value
 
+    def test_string_format_password(self):
+        schema = Schema(SchemaType.STRING, schema_format=SchemaFormat.PASSWORD)
+        value = 'password'
+
+        result = schema.unmarshal(value)
+
+        assert result == 'password'
+
     def test_string_float_invalid(self):
         schema = Schema('string')
         value = 1.23


### PR DESCRIPTION
`password` is a valid OpenAPIv3 string format, that is used as a UI hint
for frontend clients to mask the input field.

It was already present in the `SchemaFormat` enum, but it was not
handled in `_unmarshal_string` that uses `STRING_FORMAT_CALLABLE_GETTER`
to decide how to unmarshal a string, which would result in an error like
this one:

```
Traceback (most recent call last):
  [... snip ...]
  File ".venv/lib/python3.7/site-packages/openapi_core/validation/request/validators.py", line 37, in validate
    body, body_errors = self._get_body(request, operation)
  File ".venv/lib/python3.7/site-packages/openapi_core/validation/request/validators.py", line 82, in _get_body
    body = media_type.unmarshal(raw_body, self.custom_formatters)
  File ".venv/lib/python3.7/site-packages/openapi_core/schema/media_types/models.py", line 45, in unmarshal
    unmarshalled = self.schema.unmarshal(deserialized, custom_formatters=custom_formatters)
  File ".venv/lib/python3.7/site-packages/openapi_core/schema/schemas/models.py", line 189, in unmarshal
    casted = self.cast(value, custom_formatters=custom_formatters, strict=strict)
  File ".venv/lib/python3.7/site-packages/openapi_core/schema/schemas/models.py", line 179, in cast
    return cast_callable(value)
  File ".venv/lib/python3.7/site-packages/openapi_core/schema/schemas/models.py", line 295, in _unmarshal_object
    value, custom_formatters=custom_formatters)
  File ".venv/lib/python3.7/site-packages/openapi_core/schema/schemas/models.py", line 335, in _unmarshal_properties
    prop_value, custom_formatters=custom_formatters)
  File ".venv/lib/python3.7/site-packages/openapi_core/schema/schemas/models.py", line 189, in unmarshal
    casted = self.cast(value, custom_formatters=custom_formatters, strict=strict)
  File ".venv/lib/python3.7/site-packages/openapi_core/schema/schemas/models.py", line 179, in cast
    return cast_callable(value)
  File ".venv/lib/python3.7/site-packages/openapi_core/schema/schemas/models.py", line 295, in _unmarshal_object
    value, custom_formatters=custom_formatters)
  File ".venv/lib/python3.7/site-packages/openapi_core/schema/schemas/models.py", line 335, in _unmarshal_properties
    prop_value, custom_formatters=custom_formatters)
  File ".venv/lib/python3.7/site-packages/openapi_core/schema/schemas/models.py", line 189, in unmarshal
    casted = self.cast(value, custom_formatters=custom_formatters, strict=strict)
  File ".venv/lib/python3.7/site-packages/openapi_core/schema/schemas/models.py", line 179, in cast
    return cast_callable(value)
  File ".venv/lib/python3.7/site-packages/openapi_core/schema/schemas/models.py", line 215, in _unmarshal_string
    formatstring = self.STRING_FORMAT_CALLABLE_GETTER[schema_format]
KeyError: <SchemaFormat.PASSWORD: 'password'>
```