### PR TITLE
Add support for one-of with any type

### DIFF
--- a/openapi_core/schema/schemas/models.py
+++ b/openapi_core/schema/schemas/models.py
@@ -2,7 +2,6 @@
 import attr
 import functools
 import logging
-from base64 import b64decode, b64encode
 from collections import defaultdict
 from datetime import date, datetime
 from uuid import UUID

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+from datetime import datetime
 from base64 import b64encode
 from uuid import UUID
 from six import iteritems, text_type
@@ -1213,7 +1214,7 @@ class TestPetstore(object):
 
         assert parameters == {}
         assert isinstance(body, BaseModel)
-        assert body.created == created
+        assert body.created == datetime(2016, 4, 16, 16, 6, 5)
         assert body.name == pet_name
 
         code = 400
@@ -1257,7 +1258,7 @@ class TestPetstore(object):
         )
 
         parameters = request.get_parameters(spec)
-        with pytest.raises(NoValidSchema):
+        with pytest.raises(InvalidMediaTypeValue):
             request.get_body(spec)
 
         assert parameters == {}

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -20,7 +20,7 @@ from openapi_core.schema.request_bodies.models import RequestBody
 from openapi_core.schema.responses.models import Response
 from openapi_core.schema.schemas.enums import SchemaType
 from openapi_core.schema.schemas.exceptions import (
-    NoValidSchema, InvalidSchemaProperty, InvalidSchemaValue,
+    InvalidSchemaProperty, InvalidSchemaValue,
 )
 from openapi_core.schema.schemas.models import Schema
 from openapi_core.schema.servers.exceptions import InvalidServer

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -269,6 +269,33 @@ class TestSchemaUnmarshal(object):
         with pytest.raises(InvalidSchemaValue):
             schema.unmarshal(value)
 
+    def test_schema_any_one_of(self):
+        schema = Schema(one_of=[
+            Schema('string'),
+            Schema('array', items=Schema('string')),
+        ])
+        assert schema.unmarshal(['hello']) == ['hello']
+
+    def test_schema_any_one_of_mutiple(self):
+        schema = Schema(one_of=[
+            Schema('array', items=Schema('string')),
+            Schema('array', items=Schema('number')),
+        ])
+        with pytest.raises(MultipleOneOfSchema):
+            schema.unmarshal([])
+
+    def test_schema_any_one_of_no_valid(self):
+        schema = Schema(one_of=[
+            Schema('array', items=Schema('string')),
+            Schema('array', items=Schema('number')),
+        ])
+        with pytest.raises(NoOneOfSchema):
+            schema.unmarshal({})
+
+    def test_schema_any(self):
+        schema = Schema()
+        assert schema.unmarshal('string') == 'string'
+
 
 class TestSchemaValidate(object):
 


### PR DESCRIPTION
This is a rebased version of my original [PR](https://github.com/p1c2u/openapi-core/pull/114) rebased on p1c2u/master to get rid of the unnecessary strict validation changes. This pull requests adds support for various cases of oneOf in combination with a SchemaType.ANY schema that currently fail to unmarshal correctly, for example...

```yaml
Polymorphic:
  oneOf:
    Values:
      type:  array
      items:
        type: string
    Value:
      type: string
```