### PR TITLE
Modify FlaskOpenAPIRequest to accomodate path variables

### DIFF
--- a/openapi_core/wrappers/flask.py
+++ b/openapi_core/wrappers/flask.py
@@ -1,8 +1,15 @@
 """OpenAPI core wrappers module"""
+import re
+
 from openapi_core.wrappers.base import BaseOpenAPIRequest, BaseOpenAPIResponse
+
+# http://flask.pocoo.org/docs/1.0/quickstart/#variable-rules
+PATH_PARAMETER_PATTERN = r'<(?:(?:string|int|float|path|uuid):)?(\w+)>'
 
 
 class FlaskOpenAPIRequest(BaseOpenAPIRequest):
+
+    path_regex = re.compile(PATH_PARAMETER_PATTERN)
 
     def __init__(self, request):
         self.request = request
@@ -24,7 +31,7 @@ class FlaskOpenAPIRequest(BaseOpenAPIRequest):
         if self.request.url_rule is None:
             return self.path
 
-        return self.request.url_rule.rule
+        return self.path_regex.sub(r'{\1}', self.request.url_rule.rule)
 
     @property
     def parameters(self):

--- a/tests/integration/data/v3.0/flask_wrapper.yaml
+++ b/tests/integration/data/v3.0/flask_wrapper.yaml
@@ -1,0 +1,19 @@
+openapi: "3.0.0"
+info:
+  title: Basic OpenAPI specification used with test_wrappers.TestFlaskOpenAPIIValidation
+  version: "0.1"
+servers:
+  - url: 'http://localhost'
+paths:
+  '/browse/{id}/':
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: the ID of the resource to retrieve
+        schema:
+          type: integer
+    get:
+      responses:
+        default:
+          description: Return the resource.

--- a/tests/integration/test_wrappers.py
+++ b/tests/integration/test_wrappers.py
@@ -142,18 +142,25 @@ class TestFlaskOpenAPIResponse(object):
 
 class TestFlaskOpenAPIValidation(object):
 
-    specfile = 'data/v3.0/flask_wrapper.yaml'
+    @pytest.fixture
+    def flask_spec(self, factory):
+        specfile = 'data/v3.0/flask_wrapper.yaml'
+        return create_spec(factory.spec_from_file(specfile))
 
-    def test_response_validator_path_pattern(self, factory, request_factory, response_factory):
-        validator = ResponseValidator(create_spec(factory.spec_from_file(self.specfile)))
+    def test_response_validator_path_pattern(self,
+                                             flask_spec,
+                                             request_factory,
+                                             response_factory):
+        validator = ResponseValidator(flask_spec)
         request = request_factory('GET', '/browse/12/', subdomain='kb')
         openapi_request = FlaskOpenAPIRequest(request)
-        openapi_response = FlaskOpenAPIResponse(response_factory('Some item', status_code=200))
+        response = response_factory('Some item', status_code=200)
+        openapi_response = FlaskOpenAPIResponse(response)
         result = validator.validate(openapi_request, openapi_response)
         assert not result.errors
 
-    def test_request_validator_path_pattern(self, factory, request_factory):
-        validator = RequestValidator(create_spec(factory.spec_from_file(self.specfile)))
+    def test_request_validator_path_pattern(self, flask_spec, request_factory):
+        validator = RequestValidator(flask_spec)
         request = request_factory('GET', '/browse/12/', subdomain='kb')
         openapi_request = FlaskOpenAPIRequest(request)
         result = validator.validate(openapi_request)

--- a/tests/integration/test_wrappers.py
+++ b/tests/integration/test_wrappers.py
@@ -122,7 +122,7 @@ class TestFlaskOpenAPIRequest(object):
         assert openapi_request.host_url == request.host_url
         assert openapi_request.path == request.path
         assert openapi_request.method == request.method.lower()
-        assert openapi_request.path_pattern == request.url_rule.rule
+        assert openapi_request.path_pattern == '/browse/{id}/'
         assert openapi_request.body == request.data
         assert openapi_request.mimetype == request.mimetype
 


### PR DESCRIPTION
I believe this is a partial fix for #35 (see also #93). It doesn't attempt to solve the general case of accommodating all the possible routers out there. Instead, this is a limited set of changes confined to the `wrappers.flask` module that uses a regex to transform the Flask URL variables into OpenAPI path parameters.

Thanks for your work on this very useful library.