### PR TITLE
very simple and hacky path item parameter override test

### DIFF
--- a/tests/integration/test_validators.py
+++ b/tests/integration/test_validators.py
@@ -328,27 +328,6 @@ class TestPathItemParamsValidator(object):
         assert result.body is None
         assert result.parameters == {}
 
-    @pytest.mark.xfail
-    def test_request_override_invalid_param(self, spec_dict):
-        # override parameter path parameter on operation
-        # This here should result in an invalid spec object, because there are
-        # now two parameters with the same name, but different location.
-        # (The openapi3 spec is also not very explicit about this case)
-        spec_dict["paths"]["/resource"]["get"]["parameters"] = [
-            {
-                # full valid parameter object required
-                "name": "resId",
-                "in": "path",
-                "required": False,
-                "schema": {
-                    "type": "integer",
-                },
-            }
-        ]
-        from openapi_spec_validator.exceptions import OpenAPIValidationError
-        with pytest.raises(OpenAPIValidationError):
-            create_spec(spec_dict)
-
 
 class TestResponseValidator(object):
 

--- a/tests/integration/test_validators.py
+++ b/tests/integration/test_validators.py
@@ -305,7 +305,6 @@ class TestPathItemParamsValidator(object):
         assert result.body is None
         assert result.parameters == {'query': {'resId': 10}}
 
-    @pytest.mark.xfail
     def test_request_override_param(self, spec_dict):
         # override parameter path parameter on operation
         # (name and in property must match)

--- a/tests/integration/test_validators.py
+++ b/tests/integration/test_validators.py
@@ -307,7 +307,8 @@ class TestPathItemParamsValidator(object):
 
     @pytest.mark.xfail
     def test_request_override_param(self, spec_dict):
-        # override parameter path parameter on operation (name and in property must match)
+        # override parameter path parameter on operation
+        # (name and in property must match)
         spec_dict["paths"]["/resource"]["get"]["parameters"] = [
             {
                 # full valid parameter object required
@@ -346,7 +347,7 @@ class TestPathItemParamsValidator(object):
         ]
         from openapi_spec_validator.exceptions import OpenAPIValidationError
         with pytest.raises(OpenAPIValidationError):
-            spec = create_spec(spec_dict)
+            create_spec(spec_dict)
 
 
 class TestResponseValidator(object):


### PR DESCRIPTION
Hi. This is a follow up on #140 and #144.

The fix in #144 is good enough for me and solves my use case. (Thanks again @p1c2u)

However I thought I play around a bit and test overriding parameters. Here are two very simple (and hacky) test cases to demonstrate that. 

The issue of overriding `Path Item Parameters` with `Operation Parameters` is a bit more complex though. First it is possible to create an invalid `Spec` object by overriding a parameter with same name but different `in` attribute. The second part is parameter validation, which should only validate with the overridden parameter definition from the `Operation` object.

I believe it is a rather rare use case to override parameters, but I thought I'll put it up here. It does not hinder me using this fantastic library and I know that this pull-request is not really mergeable (I only put it together in one place to better demonstrate the two sides of this issue).
