### PR TITLE
Schemas defined by allOf are not treated as Objects

### DIFF
--- a/openapi_core/schema/schemas/models.py
+++ b/openapi_core/schema/schemas/models.py
@@ -113,6 +113,9 @@ class Schema(object):
         self._all_required_properties_cache = None
         self._all_optional_properties_cache = None
 
+        if self.all_of or self.one_of:
+            self.type = SchemaType.OBJECT
+
     def __getitem__(self, name):
         return self.properties[name]
 

--- a/openapi_core/schema/schemas/models.py
+++ b/openapi_core/schema/schemas/models.py
@@ -113,7 +113,7 @@ class Schema(object):
         self._all_required_properties_cache = None
         self._all_optional_properties_cache = None
 
-        if self.all_of or self.one_of:
+        if self.all_of:
             self.type = SchemaType.OBJECT
 
     def __getitem__(self, name):

--- a/tests/unit/schema/test_schemas_registry.py
+++ b/tests/unit/schema/test_schemas_registry.py
@@ -55,52 +55,51 @@ class TestSchemaRegistryGetOrCreate(BaseTestRegistry):
 
 class TestAllOf(BaseTestRegistry):
 
-        @pytest.fixture
-        def schema_dict(self):
-            return {
-                'type': 'object',
-                'properties': {
-                    'message': {
-                        'type': 'string',
-                    },
-                    'suberror': {
-                        'allOf': [
-                            {'$ref': '#/components/schemas/Error'},
-                            {'$ref': '#/components/schemas/TS'}
-                        ]
-                    }
+    @pytest.fixture
+    def schema_dict(self):
+        return {
+            'type': 'object',
+            'properties': {
+                'message': {
+                    'type': 'string',
                 },
-            }
+                'suberror': {
+                    'allOf': [
+                        {'$ref': '#/components/schemas/Error'},
+                        {'$ref': '#/components/schemas/TS'}
+                    ]
+                }
+            },
+        }
 
-        @pytest.fixture
-        def spec_dict(self, schema_dict):
-            return {
-                'components': {
-                    'schemas': {
-                        'Error': {
-                            'type': 'object',
-                            'properties': {
-                                'message': {
-                                    'type': 'string'
-                                },
-                            }
-                        },
-                        'TS': {
-                            'type': 'object',
-                            'properties': {
-                                'moment': {
-                                    'type': 'string',
-                                    'format': 'datetime'
-                                }
+    @pytest.fixture
+    def spec_dict(self, schema_dict):
+        return {
+            'components': {
+                'schemas': {
+                    'Error': {
+                        'type': 'object',
+                        'properties': {
+                            'message': {
+                                'type': 'string'
+                            },
+                        }
+                    },
+                    'TS': {
+                        'type': 'object',
+                        'properties': {
+                            'moment': {
+                                'type': 'string',
+                                'format': 'datetime'
                             }
                         }
                     }
                 }
             }
+        }
 
+    def test_all_of_intrinsic_type(self, schemas_registry, schema_dict):
+        schema, _ = schemas_registry.get_or_create(schema_dict)
 
-        def test_all_of_intrinsic_type(self, schemas_registry, schema_dict):
-            schema, _ = schemas_registry.get_or_create(schema_dict)
-
-            suberror = schema.properties['suberror']
-            assert suberror.type == SchemaType.OBJECT
+        suberror = schema.properties['suberror']
+        assert suberror.type == SchemaType.OBJECT

--- a/tests/unit/schema/test_schemas_registry.py
+++ b/tests/unit/schema/test_schemas_registry.py
@@ -4,10 +4,23 @@ from jsonschema.validators import RefResolver
 from openapi_spec_validator.validators import Dereferencer
 from openapi_spec_validator import default_handlers
 
+from openapi_core.schema.schemas.enums import SchemaType
 from openapi_core.schema.schemas.registries import SchemaRegistry
 
 
-class TestSchemaRegistryGetOrCreate(object):
+class BaseTestRegistry(object):
+
+    @pytest.fixture
+    def dereferencer(self, spec_dict):
+        spec_resolver = RefResolver('', spec_dict, handlers=default_handlers)
+        return Dereferencer(spec_resolver)
+
+    @pytest.fixture
+    def schemas_registry(self, dereferencer):
+        return SchemaRegistry(dereferencer)
+
+
+class TestSchemaRegistryGetOrCreate(BaseTestRegistry):
 
     @pytest.fixture
     def schema_dict(self):
@@ -33,17 +46,64 @@ class TestSchemaRegistryGetOrCreate(object):
             },
         }
 
-    @pytest.fixture
-    def dereferencer(self, spec_dict):
-        spec_resolver = RefResolver('', spec_dict, handlers=default_handlers)
-        return Dereferencer(spec_resolver)
-
-    @pytest.fixture
-    def schemas_registry(self, dereferencer):
-        return SchemaRegistry(dereferencer)
-
     def test_recursion(self, schemas_registry, schema_dict):
         schema, _ = schemas_registry.get_or_create(schema_dict)
 
         assert schema.properties['suberror'] ==\
             schema.properties['suberror'].properties['suberror']
+
+
+class TestAllOf(BaseTestRegistry):
+
+        @pytest.fixture
+        def schema_dict(self):
+            return {
+                'type': 'object',
+                'properties': {
+                    'message': {
+                        'type': 'string',
+                    },
+                    'suberror': {
+                        'allOf': [
+                            {'$ref': '#/components/schemas/Error'},
+                            {'$ref': '#/components/schemas/TS'}
+                        ]
+                    },
+                    'ts': {
+                        '$ref': '#/components/schemas/TS'
+                    }
+                },
+            }
+
+        @pytest.fixture
+        def spec_dict(self, schema_dict):
+            return {
+                'components': {
+                    'schemas': {
+                        'Error': {
+                            'type': 'object',
+                            'properties': {
+                                'message': {
+                                    'type': 'string'
+                                },
+                            }
+                        },
+                        'TS': {
+                            'type': 'object',
+                            'properties': {
+                                'moment': {
+                                    'type': 'string',
+                                    'format': 'datetime'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+
+        def test_all_of_intrinsic_type(self, schemas_registry, schema_dict):
+            schema, _ = schemas_registry.get_or_create(schema_dict)
+
+            suberror = schema.properties['suberror']
+            assert suberror.type == SchemaType.OBJECT

--- a/tests/unit/schema/test_schemas_registry.py
+++ b/tests/unit/schema/test_schemas_registry.py
@@ -68,9 +68,6 @@ class TestAllOf(BaseTestRegistry):
                             {'$ref': '#/components/schemas/Error'},
                             {'$ref': '#/components/schemas/TS'}
                         ]
-                    },
-                    'ts': {
-                        '$ref': '#/components/schemas/TS'
                     }
                 },
             }


### PR DESCRIPTION
Proposed fix for #147 

I've added the simplest possible code the check whether a given Schema is composed of one or more different schemas by _allOf_. Also added a test case to expose the failure.