### PR TITLE
OAS validation with JSONSchema

### DIFF
--- a/openapi_core/schema/media_types/models.py
+++ b/openapi_core/schema/media_types/models.py
@@ -51,12 +51,6 @@ class MediaType(object):
             raise InvalidMediaTypeValue(exc)
 
         try:
-            unmarshalled = self.schema.unmarshal(value, custom_formatters=custom_formatters)
-        except OpenAPISchemaError as exc:
-            raise InvalidMediaTypeValue(exc)
-
-        try:
-            return self.schema.obj_validate(
-                unmarshalled, custom_formatters=custom_formatters)
+            return self.schema.unmarshal(value, custom_formatters=custom_formatters)
         except OpenAPISchemaError as exc:
             raise InvalidMediaTypeValue(exc)

--- a/openapi_core/schema/media_types/models.py
+++ b/openapi_core/schema/media_types/models.py
@@ -32,17 +32,26 @@ class MediaType(object):
         deserializer = self.get_dererializer()
         return deserializer(value)
 
-    def unmarshal(self, value, custom_formatters=None):
+    def cast(self, value):
         if not self.schema:
             return value
 
         try:
-            deserialized = self.deserialize(value)
+            return self.deserialize(value)
         except ValueError as exc:
             raise InvalidMediaTypeValue(exc)
 
+    def unmarshal(self, value, custom_formatters=None, resolver=None):
+        if not self.schema:
+            return value
+
         try:
-            unmarshalled = self.schema.unmarshal(deserialized, custom_formatters=custom_formatters)
+            self.schema.validate(value, resolver=resolver)
+        except OpenAPISchemaError as exc:
+            raise InvalidMediaTypeValue(exc)
+
+        try:
+            unmarshalled = self.schema.unmarshal(value, custom_formatters=custom_formatters)
         except OpenAPISchemaError as exc:
             raise InvalidMediaTypeValue(exc)
 

--- a/openapi_core/schema/media_types/models.py
+++ b/openapi_core/schema/media_types/models.py
@@ -47,7 +47,7 @@ class MediaType(object):
             raise InvalidMediaTypeValue(exc)
 
         try:
-            return self.schema.validate(
+            return self.schema.obj_validate(
                 unmarshalled, custom_formatters=custom_formatters)
         except OpenAPISchemaError as exc:
             raise InvalidMediaTypeValue(exc)

--- a/openapi_core/schema/parameters/models.py
+++ b/openapi_core/schema/parameters/models.py
@@ -123,7 +123,7 @@ class Parameter(object):
             raise InvalidParameterValue(self.name, exc)
 
         try:
-            return self.schema.validate(
+            return self.schema.obj_validate(
                 unmarshalled, custom_formatters=custom_formatters)
         except OpenAPISchemaError as exc:
             raise InvalidParameterValue(self.name, exc)

--- a/openapi_core/schema/parameters/models.py
+++ b/openapi_core/schema/parameters/models.py
@@ -123,16 +123,10 @@ class Parameter(object):
             raise InvalidParameterValue(self.name, exc)
 
         try:
-            unmarshalled = self.schema.unmarshal(
+            return self.schema.unmarshal(
                 value,
                 custom_formatters=custom_formatters,
                 strict=True,
             )
-        except OpenAPISchemaError as exc:
-            raise InvalidParameterValue(self.name, exc)
-
-        try:
-            return self.schema.obj_validate(
-                unmarshalled, custom_formatters=custom_formatters)
         except OpenAPISchemaError as exc:
             raise InvalidParameterValue(self.name, exc)

--- a/openapi_core/schema/schemas/_format.py
+++ b/openapi_core/schema/schemas/_format.py
@@ -1,9 +1,105 @@
-from jsonschema._format import FormatChecker
-from six import binary_type
+from base64 import b64encode, b64decode
+import binascii
+from datetime import datetime
+from uuid import UUID
 
-oas30_format_checker = FormatChecker()
+from jsonschema._format import FormatChecker
+from jsonschema.exceptions import FormatError
+from six import binary_type, text_type, integer_types
+
+
+class StrictFormatChecker(FormatChecker):
+
+    def check(self, instance, format):
+        if format not in self.checkers:
+            raise FormatError(
+                "Format checker for %r format not found" % (format, ))
+        return super(StrictFormatChecker, self).check(
+            instance, format)
+
+
+oas30_format_checker = StrictFormatChecker()
+
+
+@oas30_format_checker.checks('int32')
+def is_int32(instance):
+    return isinstance(instance, integer_types)
+
+
+@oas30_format_checker.checks('int64')
+def is_int64(instance):
+    return isinstance(instance, integer_types)
+
+
+@oas30_format_checker.checks('float')
+def is_float(instance):
+    return isinstance(instance, float)
+
+
+@oas30_format_checker.checks('double')
+def is_double(instance):
+    # float has double precision in Python
+    # It's double in CPython and Jython
+    return isinstance(instance, float)
 
 
 @oas30_format_checker.checks('binary')
-def binary(value):
-    return isinstance(value, binary_type)
+def is_binary(instance):
+    return isinstance(instance, binary_type)
+
+
+@oas30_format_checker.checks('byte', raises=(binascii.Error, TypeError))
+def is_byte(instance):
+    if isinstance(instance, text_type):
+        instance = instance.encode()
+
+    return b64encode(b64decode(instance)) == instance
+
+
+try:
+    import strict_rfc3339
+except ImportError:
+    try:
+        import isodate
+    except ImportError:
+        pass
+    else:
+        @oas30_format_checker.checks(
+            "date-time", raises=(ValueError, isodate.ISO8601Error))
+        def is_datetime(instance):
+            if isinstance(instance, binary_type):
+                return False
+            if not isinstance(instance, text_type):
+                return True
+            return isodate.parse_datetime(instance)
+else:
+    @oas30_format_checker.checks("date-time")
+    def is_datetime(instance):
+        if isinstance(instance, binary_type):
+            return False
+        if not isinstance(instance, text_type):
+            return True
+        return strict_rfc3339.validate_rfc3339(instance)
+
+
+@oas30_format_checker.checks("date", raises=ValueError)
+def is_date(instance):
+    if isinstance(instance, binary_type):
+        return False
+    if not isinstance(instance, text_type):
+        return True
+    return datetime.strptime(instance, "%Y-%m-%d")
+
+
+@oas30_format_checker.checks("uuid", raises=AttributeError)
+def is_uuid(instance):
+    if isinstance(instance, binary_type):
+        return False
+    if not isinstance(instance, text_type):
+        return True
+    try:
+        uuid_obj = UUID(instance)
+    except ValueError:
+        return False
+
+    return text_type(uuid_obj) == instance

--- a/openapi_core/schema/schemas/_format.py
+++ b/openapi_core/schema/schemas/_format.py
@@ -1,0 +1,9 @@
+from jsonschema._format import FormatChecker
+from six import binary_type
+
+oas30_format_checker = FormatChecker()
+
+
+@oas30_format_checker.checks('binary')
+def binary(value):
+    return isinstance(value, binary_type)

--- a/openapi_core/schema/schemas/_types.py
+++ b/openapi_core/schema/schemas/_types.py
@@ -1,0 +1,21 @@
+from jsonschema._types import (
+    TypeChecker, is_any, is_array, is_bool, is_integer,
+    is_object, is_number,
+)
+from six import text_type, binary_type
+
+
+def is_string(checker, instance):
+    return isinstance(instance, (text_type, binary_type))
+
+
+oas30_type_checker = TypeChecker(
+    {
+        u"string": is_string,
+        u"number": is_number,
+        u"integer": is_integer,
+        u"boolean": is_bool,
+        u"array": is_array,
+        u"object": is_object,
+    },
+)

--- a/openapi_core/schema/schemas/_validators.py
+++ b/openapi_core/schema/schemas/_validators.py
@@ -1,4 +1,5 @@
-from jsonschema.exceptions import ValidationError
+from jsonschema._utils import find_additional_properties, extras_msg
+from jsonschema.exceptions import ValidationError, FormatError
 
 
 def type(validator, data_type, instance, schema):
@@ -7,6 +8,17 @@ def type(validator, data_type, instance, schema):
 
     if not validator.is_type(instance, data_type):
         yield ValidationError("%r is not of type %s" % (instance, data_type))
+
+
+def format(validator, format, instance, schema):
+    if instance is None:
+        return
+
+    if validator.format_checker is not None:
+        try:
+            validator.format_checker.check(instance, format)
+        except FormatError as error:
+            yield ValidationError(error.message, cause=error.cause)
 
 
 def items(validator, items, instance, schema):
@@ -21,6 +33,25 @@ def items(validator, items, instance, schema):
 def nullable(validator, is_nullable, instance, schema):
     if instance is None and not is_nullable:
         yield ValidationError("None for not nullable")
+
+
+def additionalProperties(validator, aP, instance, schema):
+    if not validator.is_type(instance, "object"):
+        return
+
+    extras = set(find_additional_properties(instance, schema))
+
+    if not extras:
+        return
+
+    if validator.is_type(aP, "object"):
+        for extra in extras:
+            for error in validator.descend(instance[extra], aP, path=extra):
+                yield error
+    elif validator.is_type(aP, "boolean"):
+        if not aP:
+            error = "Additional properties are not allowed (%s %s unexpected)"
+            yield ValidationError(error % extras_msg(extras))
 
 
 def not_implemented(validator, value, instance, schema):

--- a/openapi_core/schema/schemas/_validators.py
+++ b/openapi_core/schema/schemas/_validators.py
@@ -1,0 +1,27 @@
+from jsonschema.exceptions import ValidationError
+
+
+def type(validator, data_type, instance, schema):
+    if instance is None:
+        return
+
+    if not validator.is_type(instance, data_type):
+        yield ValidationError("%r is not of type %s" % (instance, data_type))
+
+
+def items(validator, items, instance, schema):
+    if not validator.is_type(instance, "array"):
+        return
+
+    for index, item in enumerate(instance):
+        for error in validator.descend(item, items, path=index):
+            yield error
+
+
+def nullable(validator, is_nullable, instance, schema):
+    if instance is None and not is_nullable:
+        yield ValidationError("None for not nullable")
+
+
+def not_implemented(validator, value, instance, schema):
+    pass

--- a/openapi_core/schema/schemas/exceptions.py
+++ b/openapi_core/schema/schemas/exceptions.py
@@ -66,22 +66,6 @@ class MissingSchemaProperty(OpenAPISchemaError):
         return "Missing schema property: {0}".format(self.property_name)
 
 
-@attr.s(hash=True)
-class NoOneOfSchema(OpenAPISchemaError):
-    type = attr.ib()
-
-    def __str__(self):
-        return "Exactly one valid schema type {0} should be valid, None found.".format(self.type)
-
-
-@attr.s(hash=True)
-class MultipleOneOfSchema(OpenAPISchemaError):
-    type = attr.ib()
-
-    def __str__(self):
-        return "Exactly one schema type {0} should be valid, more than one found".format(self.type)
-
-
 class UnmarshallerError(OpenAPIMappingError):
     pass
 

--- a/openapi_core/schema/schemas/factories.py
+++ b/openapi_core/schema/schemas/factories.py
@@ -50,11 +50,11 @@ class SchemaFactory(object):
 
         all_of = []
         if all_of_spec:
-            all_of = map(self.create, all_of_spec)
+            all_of = list(map(self.create, all_of_spec))
 
         one_of = []
         if one_of_spec:
-            one_of = map(self.create, one_of_spec)
+            one_of = list(map(self.create, one_of_spec))
 
         items = None
         if items_spec:
@@ -76,6 +76,7 @@ class SchemaFactory(object):
             exclusive_maximum=exclusive_maximum,
             exclusive_minimum=exclusive_minimum,
             min_properties=min_properties, max_properties=max_properties,
+            _source=schema_deref,
         )
 
     @property

--- a/openapi_core/schema/schemas/models.py
+++ b/openapi_core/schema/schemas/models.py
@@ -406,7 +406,7 @@ class Schema(object):
 
         return defaultdict(lambda: default, mapping)
 
-    def validate(self, value, custom_formatters=None):
+    def obj_validate(self, value, custom_formatters=None):
         if value is None:
             if not self.nullable:
                 raise InvalidSchemaValue("Null value for non-nullable schema of type {type}", value, self.type)
@@ -453,7 +453,7 @@ class Schema(object):
         if self.unique_items and len(set(value)) != len(value):
             raise OpenAPISchemaError("Value may not contain duplicate items")
 
-        f = functools.partial(self.items.validate,
+        f = functools.partial(self.items.obj_validate,
                               custom_formatters=custom_formatters)
         return list(map(f, value))
 
@@ -602,7 +602,7 @@ class Schema(object):
         if self.additional_properties is not True:
             for prop_name in extra_props:
                 prop_value = value[prop_name]
-                self.additional_properties.validate(
+                self.additional_properties.obj_validate(
                     prop_value, custom_formatters=custom_formatters)
 
         for prop_name, prop in iteritems(all_props):
@@ -615,7 +615,7 @@ class Schema(object):
                     continue
                 prop_value = prop.default
             try:
-                prop.validate(prop_value, custom_formatters=custom_formatters)
+                prop.obj_validate(prop_value, custom_formatters=custom_formatters)
             except OpenAPISchemaError as exc:
                 raise InvalidSchemaProperty(prop_name, original_exception=exc)
 

--- a/openapi_core/schema/schemas/types.py
+++ b/openapi_core/schema/schemas/types.py
@@ -1,0 +1,11 @@
+import attr
+
+
+@attr.s(hash=True)
+class Contribution(object):
+    src_prop_name = attr.ib()
+    src_prop_attr = attr.ib(default=None)
+    dest_prop_name = attr.ib(default=None)
+    is_list = attr.ib(default=False)
+    is_dict = attr.ib(default=False)
+    dest_default = attr.ib(default=None)

--- a/openapi_core/schema/schemas/unmarshallers.py
+++ b/openapi_core/schema/schemas/unmarshallers.py
@@ -3,7 +3,7 @@ from six import text_type, binary_type, integer_types
 from openapi_core.schema.schemas.enums import SchemaFormat, SchemaType
 from openapi_core.schema.schemas.exceptions import (
     InvalidSchemaValue, InvalidCustomFormatSchemaValue,
-    OpenAPISchemaError, MultipleOneOfSchema, NoOneOfSchema,
+    OpenAPISchemaError,
     InvalidSchemaProperty,
     UnmarshallerStrictTypeError,
 )

--- a/openapi_core/schema/schemas/validators.py
+++ b/openapi_core/schema/schemas/validators.py
@@ -33,14 +33,14 @@ class AttributeValidator(object):
         return True
 
 
-OAS30Validator = create(
+BaseOAS30Validator = create(
     meta_schema=_utils.load_schema("draft4"),
     validators={
         u"multipleOf": _validators.multipleOf,
+        # exclusiveMaximum supported inside maximum_draft3_draft4
         u"maximum": _legacy_validators.maximum_draft3_draft4,
-        u"exclusiveMaximum": _validators.exclusiveMaximum,
+        # exclusiveMinimum supported inside minimum_draft3_draft4
         u"minimum": _legacy_validators.minimum_draft3_draft4,
-        u"exclusiveMinimum": _validators.exclusiveMinimum,
         u"maxLength": _validators.maxLength,
         u"minLength": _validators.minLength,
         u"pattern": _validators.pattern,
@@ -59,9 +59,9 @@ OAS30Validator = create(
         u"not": _validators.not_,
         u"items": oas_validators.items,
         u"properties": _validators.properties,
-        u"additionalProperties": _validators.additionalProperties,
+        u"additionalProperties": oas_validators.additionalProperties,
         # TODO: adjust description
-        u"format": _validators.format,
+        u"format": oas_validators.format,
         # TODO: adjust default
         u"$ref": _validators.ref,
         # fixed OAS fields
@@ -78,3 +78,18 @@ OAS30Validator = create(
     version="oas30",
     id_of=lambda schema: schema.get(u"id", ""),
 )
+
+
+class OAS30Validator(BaseOAS30Validator):
+
+    def iter_errors(self, instance, _schema=None):
+        if _schema is None:
+                _schema = self.schema
+
+        # append defaults to trigger validator (i.e. nullable)
+        if 'nullable' not in _schema:
+            _schema.update({
+                'nullable': False,
+            })
+
+        return super(OAS30Validator, self).iter_errors(instance, _schema)

--- a/openapi_core/schema/schemas/validators.py
+++ b/openapi_core/schema/schemas/validators.py
@@ -5,34 +5,6 @@ from openapi_core.schema.schemas import _types as oas_types
 from openapi_core.schema.schemas import _validators as oas_validators
 
 
-class TypeValidator(object):
-
-    def __init__(self, *types, **options):
-        self.types = types
-        self.exclude = options.get('exclude')
-
-    def __call__(self, value):
-        if self.exclude is not None and isinstance(value, self.exclude):
-            return False
-
-        if not isinstance(value, self.types):
-            return False
-
-        return True
-
-
-class AttributeValidator(object):
-
-    def __init__(self, attribute):
-        self.attribute = attribute
-
-    def __call__(self, value):
-        if not hasattr(value, self.attribute):
-            return False
-
-        return True
-
-
 BaseOAS30Validator = create(
     meta_schema=_utils.load_schema("draft4"),
     validators={

--- a/openapi_core/schema/schemas/validators.py
+++ b/openapi_core/schema/schemas/validators.py
@@ -1,3 +1,10 @@
+from jsonschema import _legacy_validators, _format, _types, _utils, _validators
+from jsonschema.validators import create
+
+from openapi_core.schema.schemas import _types as oas_types
+from openapi_core.schema.schemas import _validators as oas_validators
+
+
 class TypeValidator(object):
 
     def __init__(self, *types, **options):
@@ -24,3 +31,50 @@ class AttributeValidator(object):
             return False
 
         return True
+
+
+OAS30Validator = create(
+    meta_schema=_utils.load_schema("draft4"),
+    validators={
+        u"multipleOf": _validators.multipleOf,
+        u"maximum": _legacy_validators.maximum_draft3_draft4,
+        u"exclusiveMaximum": _validators.exclusiveMaximum,
+        u"minimum": _legacy_validators.minimum_draft3_draft4,
+        u"exclusiveMinimum": _validators.exclusiveMinimum,
+        u"maxLength": _validators.maxLength,
+        u"minLength": _validators.minLength,
+        u"pattern": _validators.pattern,
+        u"maxItems": _validators.maxItems,
+        u"minItems": _validators.minItems,
+        u"uniqueItems": _validators.uniqueItems,
+        u"maxProperties": _validators.maxProperties,
+        u"minProperties": _validators.minProperties,
+        u"required": _validators.required,
+        u"enum": _validators.enum,
+        # adjusted to OAS
+        u"type": oas_validators.type,
+        u"allOf": _validators.allOf,
+        u"oneOf": _validators.oneOf,
+        u"anyOf": _validators.anyOf,
+        u"not": _validators.not_,
+        u"items": oas_validators.items,
+        u"properties": _validators.properties,
+        u"additionalProperties": _validators.additionalProperties,
+        # TODO: adjust description
+        u"format": _validators.format,
+        # TODO: adjust default
+        u"$ref": _validators.ref,
+        # fixed OAS fields
+        u"nullable": oas_validators.nullable,
+        u"discriminator": oas_validators.not_implemented,
+        u"readOnly": oas_validators.not_implemented,
+        u"writeOnly": oas_validators.not_implemented,
+        u"xml": oas_validators.not_implemented,
+        u"externalDocs": oas_validators.not_implemented,
+        u"example": oas_validators.not_implemented,
+        u"deprecated": oas_validators.not_implemented,
+    },
+    type_checker=oas_types.oas30_type_checker,
+    version="oas30",
+    id_of=lambda schema: schema.get(u"id", ""),
+)

--- a/openapi_core/schema/specs/factories.py
+++ b/openapi_core/schema/specs/factories.py
@@ -2,6 +2,7 @@
 """OpenAPI core specs factories module"""
 
 from openapi_spec_validator import openapi_v3_spec_validator
+from openapi_spec_validator.validators import Dereferencer
 
 from openapi_core.compat import lru_cache
 from openapi_core.schema.components.factories import ComponentsFactory
@@ -14,8 +15,8 @@ from openapi_core.schema.specs.models import Spec
 
 class SpecFactory(object):
 
-    def __init__(self, dereferencer, config=None):
-        self.dereferencer = dereferencer
+    def __init__(self, spec_resolver, config=None):
+        self.spec_resolver = spec_resolver
         self.config = config or {}
 
     def create(self, spec_dict, spec_url=''):
@@ -34,8 +35,15 @@ class SpecFactory(object):
         paths = self.paths_generator.generate(paths)
         components = self.components_factory.create(components_spec)
         spec = Spec(
-            info, list(paths), servers=list(servers), components=components)
+            info, list(paths), servers=list(servers), components=components,
+            _resolver=self.spec_resolver,
+        )
         return spec
+
+    @property
+    @lru_cache()
+    def dereferencer(self):
+        return Dereferencer(self.spec_resolver)
 
     @property
     @lru_cache()

--- a/openapi_core/schema/specs/models.py
+++ b/openapi_core/schema/specs/models.py
@@ -14,11 +14,13 @@ log = logging.getLogger(__name__)
 class Spec(object):
     """Represents an OpenAPI Specification for a service."""
 
-    def __init__(self, info, paths, servers=None, components=None):
+    def __init__(self, info, paths, servers=None, components=None, _resolver=None):
         self.info = info
         self.paths = paths and dict(paths)
         self.servers = servers or []
         self.components = components
+
+        self._resolver = _resolver
 
     def __getitem__(self, path_pattern):
         return self.get_path(path_pattern)

--- a/openapi_core/shortcuts.py
+++ b/openapi_core/shortcuts.py
@@ -1,6 +1,5 @@
 """OpenAPI core shortcuts module"""
 from jsonschema.validators import RefResolver
-from openapi_spec_validator.validators import Dereferencer
 from openapi_spec_validator import default_handlers
 
 from openapi_core.schema.media_types.exceptions import OpenAPIMediaTypeError
@@ -17,8 +16,7 @@ from openapi_core.validation.response.validators import ResponseValidator
 def create_spec(spec_dict, spec_url=''):
     spec_resolver = RefResolver(
         spec_url, spec_dict, handlers=default_handlers)
-    dereferencer = Dereferencer(spec_resolver)
-    spec_factory = SpecFactory(dereferencer)
+    spec_factory = SpecFactory(spec_resolver)
     return spec_factory.create(spec_dict, spec_url=spec_url)
 
 

--- a/openapi_core/validation/response/validators.py
+++ b/openapi_core/validation/response/validators.py
@@ -61,9 +61,17 @@ class ResponseValidator(object):
                 errors.append(exc)
             else:
                 try:
-                    data = media_type.unmarshal(raw_data, self.custom_formatters)
+                    casted = media_type.cast(raw_data)
                 except OpenAPIMappingError as exc:
                     errors.append(exc)
+                else:
+                    try:
+                        data = media_type.unmarshal(
+                            casted, self.custom_formatters,
+                            resolver=self.spec._resolver,
+                        )
+                    except OpenAPIMappingError as exc:
+                        errors.append(exc)
 
         return data, errors
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ openapi-spec-validator
 six
 lazy-object-proxy
 strict_rfc3339
+isodate
 attrs

--- a/tests/integration/data/v3.0/petstore.yaml
+++ b/tests/integration/data/v3.0/petstore.yaml
@@ -317,7 +317,10 @@ components:
             suberror:
               $ref: "#/components/schemas/ExtendedError"
       additionalProperties:
-        type: string
+        oneOf:
+          - type: string
+          - type: integer
+            format: int32
   responses:
     ErrorResponse:
       description: unexpected error

--- a/tests/integration/test_validators.py
+++ b/tests/integration/test_validators.py
@@ -421,6 +421,17 @@ class TestResponseValidator(object):
         assert result.data is None
         assert result.headers == {}
 
+    def test_invalid_media_type(self, validator):
+        request = MockRequest(self.host_url, 'get', '/v1/pets')
+        response = MockResponse("abcde")
+
+        result = validator.validate(request, response)
+
+        assert len(result.errors) == 1
+        assert type(result.errors[0]) == InvalidMediaTypeValue
+        assert result.data is None
+        assert result.headers == {}
+
     def test_invalid_media_type_value(self, validator):
         request = MockRequest(self.host_url, 'get', '/v1/pets')
         response = MockResponse("{}")
@@ -458,7 +469,10 @@ class TestResponseValidator(object):
             'data': [
                 {
                     'id': 1,
-                    'name': 'Sparky'
+                    'name': 'Sparky',
+                    'ears': {
+                        'healthy': True,
+                    },
                 },
             ],
         }

--- a/tests/unit/schema/test_media_types.py
+++ b/tests/unit/schema/test_media_types.py
@@ -1,0 +1,53 @@
+import pytest
+
+from openapi_core.schema.media_types.exceptions import InvalidMediaTypeValue
+from openapi_core.schema.media_types.models import MediaType
+from openapi_core.schema.schemas.models import Schema
+
+
+class TestMediaTypeCast(object):
+
+    def test_empty(self):
+        media_type = MediaType('application/json')
+        value = ''
+
+        result = media_type.cast(value)
+
+        assert result == value
+
+
+class TestParameterUnmarshal(object):
+
+    def test_empty(self):
+        media_type = MediaType('application/json')
+        value = ''
+
+        result = media_type.unmarshal(value)
+
+        assert result == value
+
+    def test_schema_type_invalid(self):
+        schema = Schema('integer', _source={'type': 'integer'})
+        media_type = MediaType('application/json', schema=schema)
+        value = 'test'
+
+        with pytest.raises(InvalidMediaTypeValue):
+            media_type.unmarshal(value)
+
+    def test_schema_custom_format_invalid(self):
+        def custom_formatter(value):
+            raise ValueError
+        schema = Schema(
+            'string',
+            schema_format='custom',
+            _source={'type': 'string', 'format': 'custom'},
+        )
+        custom_formatters = {
+            'custom': custom_formatter,
+        }
+        media_type = MediaType('application/json', schema=schema)
+        value = 'test'
+
+        with pytest.raises(InvalidMediaTypeValue):
+            media_type.unmarshal(
+                value, custom_formatters=custom_formatters)

--- a/tests/unit/schema/test_schemas.py
+++ b/tests/unit/schema/test_schemas.py
@@ -328,7 +328,7 @@ class TestSchemaUnmarshal(object):
         assert schema.unmarshal('string') == 'string'
 
 
-class TestSchemaValidate(object):
+class TestSchemaObjValidate(object):
 
     @pytest.mark.parametrize('schema_type', [
         'boolean', 'array', 'integer', 'number', 'string',
@@ -338,7 +338,7 @@ class TestSchemaValidate(object):
         value = None
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('schema_type', [
         'boolean', 'array', 'integer', 'number', 'string',
@@ -347,7 +347,7 @@ class TestSchemaValidate(object):
         schema = Schema(schema_type, nullable=True)
         value = None
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result is None
 
@@ -355,7 +355,7 @@ class TestSchemaValidate(object):
     def test_boolean(self, value):
         schema = Schema('boolean')
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -364,20 +364,20 @@ class TestSchemaValidate(object):
         schema = Schema('boolean')
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [[1, 2], (3, 4)])
     def test_array_no_schema(self, value):
         schema = Schema('array')
 
         with pytest.raises(OpenAPISchemaError):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [[1, 2], (3, 4)])
     def test_array(self, value):
         schema = Schema('array', items=Schema('integer'))
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -386,13 +386,13 @@ class TestSchemaValidate(object):
         schema = Schema('array')
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [1, 3])
     def test_integer(self, value):
         schema = Schema('integer')
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -401,20 +401,20 @@ class TestSchemaValidate(object):
         schema = Schema('integer')
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [0, 1, 2])
     def test_integer_minimum_invalid(self, value):
         schema = Schema('integer', minimum=3)
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [4, 5, 6])
     def test_integer_minimum(self, value):
         schema = Schema('integer', minimum=3)
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -423,13 +423,13 @@ class TestSchemaValidate(object):
         schema = Schema('integer', maximum=3)
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [0, 1, 2])
     def test_integer_maximum(self, value):
         schema = Schema('integer', maximum=3)
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -438,13 +438,13 @@ class TestSchemaValidate(object):
         schema = Schema('integer', multiple_of=3)
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [3, 6, 18])
     def test_integer_multiple_of(self, value):
         schema = Schema('integer', multiple_of=3)
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -452,7 +452,7 @@ class TestSchemaValidate(object):
     def test_number(self, value):
         schema = Schema('number')
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -461,20 +461,20 @@ class TestSchemaValidate(object):
         schema = Schema('number')
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [0, 1, 2])
     def test_number_minimum_invalid(self, value):
         schema = Schema('number', minimum=3)
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [3, 4, 5])
     def test_number_minimum(self, value):
         schema = Schema('number', minimum=3)
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -483,13 +483,13 @@ class TestSchemaValidate(object):
         schema = Schema('number', minimum=3, exclusive_minimum=3)
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [4, 5, 6])
     def test_number_exclusive_minimum(self, value):
         schema = Schema('number', minimum=3)
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -498,13 +498,13 @@ class TestSchemaValidate(object):
         schema = Schema('number', maximum=3)
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [1, 2, 3])
     def test_number_maximum(self, value):
         schema = Schema('number', maximum=3)
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -513,13 +513,13 @@ class TestSchemaValidate(object):
         schema = Schema('number', maximum=3, exclusive_maximum=True)
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [0, 1, 2])
     def test_number_exclusive_maximum(self, value):
         schema = Schema('number', maximum=3, exclusive_maximum=True)
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -528,13 +528,13 @@ class TestSchemaValidate(object):
         schema = Schema('number', multiple_of=3)
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [3, 6, 18])
     def test_number_multiple_of(self, value):
         schema = Schema('number', multiple_of=3)
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -542,7 +542,7 @@ class TestSchemaValidate(object):
     def test_string(self, value):
         schema = Schema('string')
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -551,7 +551,7 @@ class TestSchemaValidate(object):
         schema = Schema('string')
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [
         b('true'), u('test'), False, 1, 3.14, [1, 3],
@@ -561,7 +561,7 @@ class TestSchemaValidate(object):
         schema = Schema('string', schema_format='date')
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [
         datetime.date(1989, 1, 2), datetime.date(2018, 1, 2),
@@ -569,7 +569,7 @@ class TestSchemaValidate(object):
     def test_string_format_date(self, value):
         schema = Schema('string', schema_format='date')
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -579,7 +579,7 @@ class TestSchemaValidate(object):
     def test_string_format_uuid(self, value):
         schema = Schema('string', schema_format='uuid')
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -591,7 +591,7 @@ class TestSchemaValidate(object):
         schema = Schema('string', schema_format='uuid')
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [
         b('true'), u('true'), False, 1, 3.14, [1, 3],
@@ -601,7 +601,7 @@ class TestSchemaValidate(object):
         schema = Schema('string', schema_format='date-time')
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [
         datetime.datetime(1989, 1, 2, 0, 0, 0),
@@ -610,7 +610,7 @@ class TestSchemaValidate(object):
     def test_string_format_datetime(self, value):
         schema = Schema('string', schema_format='date-time')
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -622,7 +622,7 @@ class TestSchemaValidate(object):
         schema = Schema('string', schema_format='binary')
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [
         b('stream'), b('text'),
@@ -630,7 +630,7 @@ class TestSchemaValidate(object):
     def test_string_format_binary(self, value):
         schema = Schema('string', schema_format='binary')
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -641,7 +641,7 @@ class TestSchemaValidate(object):
         schema = Schema('string', schema_format='byte')
 
         with pytest.raises(OpenAPISchemaError):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [
         u('tsssst'), u('dGVzdA=='),
@@ -649,7 +649,7 @@ class TestSchemaValidate(object):
     def test_string_format_byte(self, value):
         schema = Schema('string', schema_format='byte')
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -662,27 +662,27 @@ class TestSchemaValidate(object):
         schema = Schema('string', schema_format=unknown_format)
 
         with pytest.raises(OpenAPISchemaError):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [u(""), ])
     def test_string_min_length_invalid_schema(self, value):
         schema = Schema('string', min_length=-1)
 
         with pytest.raises(OpenAPISchemaError):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [u(""), u("a"), u("ab")])
     def test_string_min_length_invalid(self, value):
         schema = Schema('string', min_length=3)
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [u("abc"), u("abcd")])
     def test_string_min_length(self, value):
         schema = Schema('string', min_length=3)
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -691,20 +691,20 @@ class TestSchemaValidate(object):
         schema = Schema('string', max_length=-1)
 
         with pytest.raises(OpenAPISchemaError):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [u("ab"), u("abc")])
     def test_string_max_length_invalid(self, value):
         schema = Schema('string', max_length=1)
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [u(""), u("a")])
     def test_string_max_length(self, value):
         schema = Schema('string', max_length=1)
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -713,13 +713,13 @@ class TestSchemaValidate(object):
         schema = Schema('string', pattern='baz')
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [u("bar"), u("foobar")])
     def test_string_pattern(self, value):
         schema = Schema('string', pattern='bar')
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -728,7 +728,7 @@ class TestSchemaValidate(object):
         schema = Schema('object')
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [Model(), ])
     def test_object_multiple_one_of(self, value):
@@ -738,7 +738,7 @@ class TestSchemaValidate(object):
         schema = Schema('object', one_of=one_of)
 
         with pytest.raises(MultipleOneOfSchema):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [Model(), ])
     def test_object_defferent_type_one_of(self, value):
@@ -748,7 +748,7 @@ class TestSchemaValidate(object):
         schema = Schema('object', one_of=one_of)
 
         with pytest.raises(MultipleOneOfSchema):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [Model(), ])
     def test_object_no_one_of(self, value):
@@ -767,7 +767,7 @@ class TestSchemaValidate(object):
         schema = Schema('object', one_of=one_of)
 
         with pytest.raises(NoOneOfSchema):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [
         Model({
@@ -800,13 +800,13 @@ class TestSchemaValidate(object):
         ]
         schema = Schema('object', one_of=one_of)
 
-        schema.validate(value)
+        schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [Model(), ])
     def test_object_default_property(self, value):
         schema = Schema('object', default='value1')
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -815,7 +815,7 @@ class TestSchemaValidate(object):
         schema = Schema('object', min_properties=-1)
 
         with pytest.raises(OpenAPISchemaError):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [
         Model({'a': 1}),
@@ -830,7 +830,7 @@ class TestSchemaValidate(object):
         )
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [
         Model({'a': 1}),
@@ -844,7 +844,7 @@ class TestSchemaValidate(object):
             min_properties=1,
         )
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -853,7 +853,7 @@ class TestSchemaValidate(object):
         schema = Schema('object', max_properties=-1)
 
         with pytest.raises(OpenAPISchemaError):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [
         Model({'a': 1}),
@@ -868,7 +868,7 @@ class TestSchemaValidate(object):
         )
 
         with pytest.raises(InvalidSchemaValue):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [
         Model({'a': 1}),
@@ -882,7 +882,7 @@ class TestSchemaValidate(object):
             max_properties=3,
         )
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -890,21 +890,21 @@ class TestSchemaValidate(object):
     def test_object_additional_propetries(self, value):
         schema = Schema('object')
 
-        schema.validate(value)
+        schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [Model({'additional': 1}), ])
     def test_object_additional_propetries_false(self, value):
         schema = Schema('object', additional_properties=False)
 
         with pytest.raises(UndefinedSchemaProperty):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [Model({'additional': 1}), ])
     def test_object_additional_propetries_object(self, value):
         additional_properties = Schema('integer')
         schema = Schema('object', additional_properties=additional_properties)
 
-        schema.validate(value)
+        schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [[], ])
     def test_list_min_items_invalid_schema(self, value):
@@ -915,7 +915,7 @@ class TestSchemaValidate(object):
         )
 
         with pytest.raises(OpenAPISchemaError):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [[], [1], [1, 2]])
     def test_list_min_items_invalid(self, value):
@@ -926,7 +926,7 @@ class TestSchemaValidate(object):
         )
 
         with pytest.raises(Exception):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [[], [1], [1, 2]])
     def test_list_min_items(self, value):
@@ -936,7 +936,7 @@ class TestSchemaValidate(object):
             min_items=0,
         )
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -949,7 +949,7 @@ class TestSchemaValidate(object):
         )
 
         with pytest.raises(OpenAPISchemaError):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [[1, 2], [2, 3, 4]])
     def test_list_max_items_invalid(self, value):
@@ -960,7 +960,7 @@ class TestSchemaValidate(object):
         )
 
         with pytest.raises(Exception):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [[1, 2, 1], [2, 2]])
     def test_list_unique_items_invalid(self, value):
@@ -971,7 +971,7 @@ class TestSchemaValidate(object):
         )
 
         with pytest.raises(Exception):
-            schema.validate(value)
+            schema.obj_validate(value)
 
     @pytest.mark.parametrize('value', [
         Model({
@@ -994,7 +994,7 @@ class TestSchemaValidate(object):
             },
         )
 
-        result = schema.validate(value)
+        result = schema.obj_validate(value)
 
         assert result == value
 
@@ -1034,4 +1034,4 @@ class TestSchemaValidate(object):
         )
 
         with pytest.raises(Exception):
-            schema.validate(value)
+            schema.obj_validate(value)


### PR DESCRIPTION
New OAS validation will fix many issues with schema validation in openapi core.

Fixes #155 #147 #129 #127 #122 #115 #103 #77

Partially fixes #139 #100 (see https://github.com/p1c2u/openapi-core/pull/157/files#diff-c509eb72d0b1058bf79f8f2ac563b7afR231).