### PR TITLE
webob support

### DIFF
--- a/openapi_core/schema/parameters/models.py
+++ b/openapi_core/schema/parameters/models.py
@@ -87,6 +87,8 @@ class Parameter(object):
             return self.schema.default
 
         if self.aslist and self.explode:
+            if hasattr(location, 'getall'):
+                return location.getall(self.name)
             return location.getlist(self.name)
 
         return location[self.name]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,3 +4,4 @@ pytest-flake8
 pytest-cov==2.5.1
 flask
 django==2.2.6; python_version>="3.0"
+webob

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ tests_require =
     pytest-flake8
     pytest-cov
     flask
+    webob
 
 [options.packages.find]
 exclude =

--- a/tests/integration/validation/test_validators.py
+++ b/tests/integration/validation/test_validators.py
@@ -94,7 +94,7 @@ class TestRequestValidator(object):
     def test_get_pets(self, validator):
         request = MockRequest(
             self.host_url, 'get', '/v1/pets',
-            path_pattern='/v1/pets', args={'limit': '10'},
+            path_pattern='/v1/pets', args={'limit': '10', 'ids': ['1', '2']},
         )
 
         result = validator.validate(request)
@@ -106,6 +106,31 @@ class TestRequestValidator(object):
                 'limit': 10,
                 'page': 1,
                 'search': '',
+                'ids': [1, 2],
+            },
+        )
+
+    def test_get_pets_webob(self, validator):
+        from webob.multidict import GetDict
+        request = MockRequest(
+            self.host_url, 'get', '/v1/pets',
+            path_pattern='/v1/pets',
+        )
+        request.parameters.query = GetDict(
+            [('limit', '5'), ('ids', '1'), ('ids', '2')],
+            {}
+        )
+
+        result = validator.validate(request)
+
+        assert result.errors == []
+        assert result.body is None
+        assert result.parameters == RequestParameters(
+            query={
+                'limit': 5,
+                'page': 1,
+                'search': '',
+                'ids': [1, 2],
             },
         )
 


### PR DESCRIPTION
`webob` (used by pyramid) 's multidict protocol does not have `getlist` method, use `getall` instead of `getlist`.