### PR TITLE
Fix Requests.response factory

### DIFF
--- a/openapi_core/contrib/requests/responses.py
+++ b/openapi_core/contrib/requests/responses.py
@@ -8,7 +8,7 @@ class RequestsOpenAPIResponseFactory(object):
     def create(cls, response):
         mimetype = response.headers.get('Content-Type')
         return OpenAPIResponse(
-            data=response.raw,
+            data=response.content,
             status_code=response.status_code,
             mimetype=mimetype,
         )

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,4 +6,5 @@ falcon==2.0.0
 flask
 django==2.2.10; python_version>="3.0"
 requests==2.22.0
+responses==0.10.12
 webob

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ tests_require =
     pytest-cov
     falcon
     flask
+    responses
     webob
 
 [options.packages.find]

--- a/tests/integration/contrib/requests/conftest.py
+++ b/tests/integration/contrib/requests/conftest.py
@@ -1,7 +1,9 @@
 import pytest
 from requests.models import Request, Response
 from requests.structures import CaseInsensitiveDict
+from six import BytesIO, b
 from six.moves.urllib.parse import urljoin, parse_qs
+from urllib3.response import HTTPResponse
 
 
 @pytest.fixture
@@ -24,11 +26,13 @@ def request_factory():
 def response_factory():
     def create_response(
             data, status_code=200, content_type='application/json'):
+        fp = BytesIO(b(data))
+        raw = HTTPResponse(fp, preload_content=False)
         resp = Response()
         resp.headers = CaseInsensitiveDict({
             'Content-Type': content_type,
         })
         resp.status_code = status_code
-        resp.raw = data
+        resp.raw = raw
         return resp
     return create_response

--- a/tests/integration/contrib/requests/test_requests_responses.py
+++ b/tests/integration/contrib/requests/test_requests_responses.py
@@ -1,0 +1,14 @@
+from openapi_core.contrib.requests import RequestsOpenAPIResponse
+
+
+class TestRequestsOpenAPIResponse(object):
+
+    def test_invalid_server(self, response_factory):
+        response = response_factory('Not Found', status_code=404)
+
+        openapi_response = RequestsOpenAPIResponse(response)
+
+        assert openapi_response.data == response.content
+        assert openapi_response.status_code == response.status_code
+        mimetype = response.headers.get('Content-Type')
+        assert openapi_response.mimetype == mimetype


### PR DESCRIPTION
Requests.response attribute `raw` is filelike object. During response validation it fails due to DeserializationError. It is the way the response.raw is treated like string or bytes object, witch it isn't.
`content` attribute on the other hand does exatctly wahat is expected.