### PR TITLE
Templating parser path parameter search fix

### DIFF
--- a/openapi_core/templating/util.py
+++ b/openapi_core/templating/util.py
@@ -1,13 +1,32 @@
 from parse import Parser
 
 
+class ExtendedParser(Parser):
+    def _handle_field(self, field):
+        # handle as path parameter field
+        field = field[1:-1]
+        path_parameter_field = "{%s:PathParameter}" % field
+        return super(ExtendedParser, self)._handle_field(
+            path_parameter_field)
+
+
+def parse_path_parameter(text):
+    return text
+
+
+parse_path_parameter.pattern = r"[^\/]+"
+parse_path_parameter.name = "PathParameter"
+
+
 def search(path_pattern, full_url_pattern):
-    p = Parser(path_pattern)
+    extra_types = {parse_path_parameter.name: parse_path_parameter}
+    p = ExtendedParser(path_pattern, extra_types)
     p._expression = p._expression + '$'
     return p.search(full_url_pattern)
 
 
 def parse(server_url, server_url_pattern):
-    p = Parser(server_url)
+    extra_types = {parse_path_parameter.name: parse_path_parameter}
+    p = ExtendedParser(server_url, extra_types)
     p._expression = '^' + p._expression
     return p.parse(server_url_pattern)

--- a/tests/unit/templating/test_util.py
+++ b/tests/unit/templating/test_util.py
@@ -1,0 +1,24 @@
+from openapi_core.templating.util import search
+
+
+class TestSearch:
+
+    def test_endswith(self):
+        path_patter = '/{test}/test'
+        full_url_pattern = '/test1/test/test2/test'
+
+        result = search(path_patter, full_url_pattern)
+
+        assert result.named == {
+            'test': 'test2',
+        }
+
+    def test_exact(self):
+        path_patter = '/{test}/test'
+        full_url_pattern = '/test/test'
+
+        result = search(path_patter, full_url_pattern)
+
+        assert result.named == {
+            'test': 'test',
+        }


### PR DESCRIPTION
Adds PathParameter extra type (no slash chars)
Extended parser uses PathParameter as default type.

Fixes #226