### PR TITLE
Fix recursion on self references in arrays

### DIFF
--- a/openapi_core/schema/schemas/factories.py
+++ b/openapi_core/schema/schemas/factories.py
@@ -1,6 +1,7 @@
 """OpenAPI core schemas factories module"""
 import logging
 
+from lazy_object_proxy import Proxy
 from six import iteritems
 
 from openapi_core.compat import lru_cache
@@ -98,6 +99,9 @@ class SchemaFactory(object):
         return PropertiesGenerator(self.dereferencer, self)
 
     def _create_items(self, items_spec):
+        if '$ref' in items_spec:
+            return Proxy(lambda: self.create(items_spec))
+
         return self.create(items_spec)
 
 

--- a/tests/unit/schema/test_schemas_registry.py
+++ b/tests/unit/schema/test_schemas_registry.py
@@ -20,6 +20,12 @@ class TestSchemaRegistryGetOrCreate(object):
                 'suberror': {
                     '$ref': '#/components/schemas/Error',
                 },
+                'suberrors': {
+                    'items': {
+                        '$ref': '#/components/schemas/Error'
+                    },
+                    'type': 'array'
+                }
             },
         }
 
@@ -47,3 +53,9 @@ class TestSchemaRegistryGetOrCreate(object):
 
         assert schema.properties['suberror'] ==\
             schema.properties['suberror'].properties['suberror']
+
+    def test_array_recursion(self, schemas_registry, schema_dict):
+        schema, _ = schemas_registry.get_or_create(schema_dict)
+
+        assert schema.properties['suberrors'].items ==\
+            schema.properties['suberrors'].items.properties['suberrors'].items


### PR DESCRIPTION
It seems as though the issue with self reference recursion has been fixed, though self references on array types are still causing an error. 

This fixes the problem, though there may be a better way to do it?