### PR TITLE
Small change to Schema model to allow generated specs to be picklable

### DIFF
--- a/openapi_core/schema/schemas/models.py
+++ b/openapi_core/schema/schemas/models.py
@@ -67,8 +67,12 @@ class Schema(object):
 
         self._source = _source
 
+    # Overriding object.__dict__ is a VERY bad idea as it totally breaks any
+    # possibility of pickling this object.  Pickling marshalls via object.__dict__
+    # via default __getstate__ and __setstate__ methods.  This is now renamed to
+    # keep the functionality for the validators, but keep pickling operational.
     @property
-    def __dict__(self):
+    def __newdict__(self):
         return self._source or self.to_dict()
 
     def to_dict(self):

--- a/openapi_core/unmarshalling/schemas/factories.py
+++ b/openapi_core/unmarshalling/schemas/factories.py
@@ -86,7 +86,7 @@ class SchemaUnmarshallersFactory(object):
         }
         if self.context is not None:
             kwargs[self.CONTEXT_VALIDATION[self.context]] = True
-        return OAS30Validator(schema.__dict__, **kwargs)
+        return OAS30Validator(schema.__newdict__, **kwargs)
 
     def _get_format_checker(self):
         fc = deepcopy(oas30_format_checker)


### PR DESCRIPTION
This reverts commit f6ba057fd26100337c9c775669cc6eb204e92a6f.

PR #243 was failing

https://travis-ci.org/github/p1c2u/openapi-core/builds/710002316