### PR TITLE
use prepared request to format payload before converting

### DIFF
--- a/openapi_core/contrib/requests/requests.py
+++ b/openapi_core/contrib/requests/requests.py
@@ -26,11 +26,10 @@ class RequestsOpenAPIRequestFactory(object):
         method = request.method.lower()
 
         # Cookies
+        cookie = {}
         if request._cookies is not None:
             # cookies are stored in a cookiejar object
             cookie = request._cookies.get_dict()
-        else:
-            cookie = {}
 
         # Preparing a request formats the URL with params, strip them out again
         o = urlparse(request.url)

--- a/openapi_core/contrib/requests/requests.py
+++ b/openapi_core/contrib/requests/requests.py
@@ -1,5 +1,8 @@
 """OpenAPI core contrib requests requests module"""
+from typing import Union
 from werkzeug.datastructures import ImmutableMultiDict
+from requests import Request, PreparedRequest
+from urllib.parse import urlparse, parse_qs
 
 from openapi_core.validation.request.datatypes import (
     RequestParameters, OpenAPIRequest,
@@ -9,26 +12,57 @@ from openapi_core.validation.request.datatypes import (
 class RequestsOpenAPIRequestFactory(object):
 
     @classmethod
-    def create(cls, request):
+    def create(cls, request: Union[Request, PreparedRequest]) -> OpenAPIRequest:
+        """
+        Converts a requests request to an OpenAPI one
+
+        Internally converts to a `PreparedRequest` first to parse the exact
+        payload being sent
+        """
+        if isinstance(request, Request):
+            request = request.prepare()
+
+        # Method
         method = request.method.lower()
 
-        cookie = request.cookies or {}
+        # Cookies
+        if request._cookies is not None:
+            # cookies are stored in a cookiejar object
+            cookie = request._cookies.get_dict()
+        else:
+            cookie = {}
+
+        # Preparing a request formats the URL with params, strip them out again
+        o = urlparse(request.url)
+        params = parse_qs(o.query)
+        # extract the URL without query parameters
+        url = o._replace(query=None).geturl()
 
         # gets deduced by path finder against spec
         path = {}
 
-        mimetype = request.headers.get('Accept') or \
-            request.headers.get('Content-Type')
+        # Order matters because all python requests issued from a session include
+        # Accept */* which does not necessarily match the content type
+        mimetype = request.headers.get('Content-Type') or \
+            request.headers.get('Accept')
+
+        # Headers - request.headers is not an instance of dict, which is expected
+        header = dict(request.headers)
+
+        # Body
+        # TODO: figure out if request._body_position is relevant
+        body = request.body
+
         parameters = RequestParameters(
-            query=ImmutableMultiDict(request.params),
-            header=request.headers,
+            query=ImmutableMultiDict(params),
+            header=header,
             cookie=cookie,
             path=path,
         )
         return OpenAPIRequest(
-            full_url_pattern=request.url,
+            full_url_pattern=url,
             method=method,
             parameters=parameters,
-            body=request.data,
+            body=body,
             mimetype=mimetype,
         )

--- a/openapi_core/contrib/requests/requests.py
+++ b/openapi_core/contrib/requests/requests.py
@@ -1,8 +1,8 @@
 """OpenAPI core contrib requests requests module"""
-from typing import Union
+from __future__ import absolute_import
 from werkzeug.datastructures import ImmutableMultiDict
-from requests import Request, PreparedRequest
-from urllib.parse import urlparse, parse_qs
+from requests import Request
+from six.moves.urllib.parse import urlparse, parse_qs
 
 from openapi_core.validation.request.datatypes import (
     RequestParameters, OpenAPIRequest,
@@ -12,7 +12,7 @@ from openapi_core.validation.request.datatypes import (
 class RequestsOpenAPIRequestFactory(object):
 
     @classmethod
-    def create(cls, request: Union[Request, PreparedRequest]) -> OpenAPIRequest:
+    def create(cls, request):
         """
         Converts a requests request to an OpenAPI one
 
@@ -40,12 +40,13 @@ class RequestsOpenAPIRequestFactory(object):
         # gets deduced by path finder against spec
         path = {}
 
-        # Order matters because all python requests issued from a session include
-        # Accept */* which does not necessarily match the content type
+        # Order matters because all python requests issued from a session
+        # include Accept */* which does not necessarily match the content type
         mimetype = request.headers.get('Content-Type') or \
             request.headers.get('Accept')
 
-        # Headers - request.headers is not an instance of dict, which is expected
+        # Headers - request.headers is not an instance of dict
+        # which is expected
         header = dict(request.headers)
 
         # Body

--- a/tests/integration/contrib/requests/data/v3.0/requests_factory.yaml
+++ b/tests/integration/contrib/requests/data/v3.0/requests_factory.yaml
@@ -13,7 +13,25 @@ paths:
         description: the ID of the resource to retrieve
         schema:
           type: integer
-    get:
+      - name: q
+        in: query
+        required: true
+        description: query key
+        schema:
+          type: string
+    post:
+      requestBody:
+        description: request data
+        required: True
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - param1
+              properties:
+                param1:
+                  type: integer
       responses:
         200:
           description: Return the resource.

--- a/tests/integration/contrib/requests/test_requests_requests.py
+++ b/tests/integration/contrib/requests/test_requests_requests.py
@@ -15,6 +15,7 @@ class TestRequestsOpenAPIRequest(object):
         query = ImmutableMultiDict([])
         headers = request.headers
         cookies = {}
+        prepared = request.prepare()
         assert openapi_request.parameters == RequestParameters(
             path=path,
             query=query,
@@ -23,7 +24,7 @@ class TestRequestsOpenAPIRequest(object):
         )
         assert openapi_request.method == request.method.lower()
         assert openapi_request.full_url_pattern == 'http://localhost/'
-        assert openapi_request.body == request.data
+        assert openapi_request.body == prepared.body
         assert openapi_request.mimetype == 'application/json'
 
     def test_multiple_values(self, request_factory, request):
@@ -44,9 +45,10 @@ class TestRequestsOpenAPIRequest(object):
             header=headers,
             cookie=cookies,
         )
+        prepared = request.prepare()
         assert openapi_request.method == request.method.lower()
         assert openapi_request.full_url_pattern == 'http://localhost/'
-        assert openapi_request.body == request.data
+        assert openapi_request.body == prepared.body
         assert openapi_request.mimetype == 'application/json'
 
     def test_url_rule(self, request_factory, request):
@@ -57,7 +59,9 @@ class TestRequestsOpenAPIRequest(object):
         # empty when not bound to spec
         path = {}
         query = ImmutableMultiDict([])
-        headers = request.headers
+        headers = (
+            ('Content-Type', 'application/json'),
+        )
         cookies = {}
         assert openapi_request.parameters == RequestParameters(
             path=path,
@@ -65,8 +69,9 @@ class TestRequestsOpenAPIRequest(object):
             header=headers,
             cookie=cookies,
         )
+        prepared = request.prepare()
         assert openapi_request.method == request.method.lower()
         assert openapi_request.full_url_pattern == \
             'http://localhost/browse/12/'
-        assert openapi_request.body == request.data
+        assert openapi_request.body == prepared.body
         assert openapi_request.mimetype == 'application/json'


### PR DESCRIPTION
Use requests.PreparedRequest object to convert requests.Request into a formatted payload before converting into an OpenAPI request.

Fixes bug where one of the many requests.Request convenience methods (ex json) are used and payload is not stored in Request.data. Should also handle scenarios where persistent sessions have expected headers not applied to the request object until it is prepared and sent