### PR TITLE
ArrayUnmarshaller: return None on nullable type instead of "NoneType object is not iterable" crash

### DIFF
--- a/openapi_core/unmarshalling/schemas/unmarshallers.py
+++ b/openapi_core/unmarshalling/schemas/unmarshallers.py
@@ -144,7 +144,8 @@ class ArrayUnmarshaller(ComplexUnmarshaller):
 
     def __call__(self, value=NoValue):
         value = super(ArrayUnmarshaller, self).__call__(value)
-
+        if value is None and self.schema.nullable:
+            return None
         return list(map(self.items_unmarshaller, value))
 
 

--- a/tests/unit/unmarshalling/test_unmarshal.py
+++ b/tests/unit/unmarshalling/test_unmarshal.py
@@ -352,6 +352,27 @@ class TestSchemaUnmarshallerCall(object):
 
         assert result == value
 
+    def test_array_null(self, unmarshaller_factory):
+        schema = Schema(
+            'array',
+            items=Schema('integer'),
+        )
+        value = None
+
+        with pytest.raises(TypeError):
+            unmarshaller_factory(schema)(value)
+
+    def test_array_nullable(self, unmarshaller_factory):
+        schema = Schema(
+            'array',
+            items=Schema('integer'),
+            nullable=True,
+        )
+        value = None
+        result = unmarshaller_factory(schema)(value)
+
+        assert result is None
+
     def test_array_of_string_string_invalid(self, unmarshaller_factory):
         schema = Schema('array', items=Schema('string'))
         value = '123'


### PR DESCRIPTION
See: https://github.com/p1c2u/openapi-core/issues/251

Addresses this point specifically:
```
When nullable is set for arrays (i.e. type: array & nullable: true), null value not being properly validated, instead, it raising error: 'NoneType' object is not iterable. So, the same issue that diogobaeder reported in the second post.
```