### PR TITLE
Add extensions support for the Parameter model

### DIFF
--- a/openapi_core/schema/parameters/factories.py
+++ b/openapi_core/schema/parameters/factories.py
@@ -1,6 +1,7 @@
 """OpenAPI core parameters factories module"""
 from openapi_core.compat import lru_cache
 from openapi_core.schema.content.factories import ContentFactory
+from openapi_core.schema.extensions.generators import ExtensionsGenerator
 from openapi_core.schema.parameters.models import Parameter
 
 
@@ -32,14 +33,22 @@ class ParameterFactory(object):
         if content_spec:
             content = self.content_factory.create(content_spec)
 
+        extensions = self.extensions_generator.generate(parameter_deref)
+
         return Parameter(
             parameter_name, parameter_in,
             schema=schema, required=required,
             allow_empty_value=allow_empty_value,
             style=style, explode=explode, content=content,
+            extensions=extensions,
         )
 
     @property
     @lru_cache()
     def content_factory(self):
         return ContentFactory(self.dereferencer, self.schemas_registry)
+
+    @property
+    @lru_cache()
+    def extensions_generator(self):
+        return ExtensionsGenerator(self.dereferencer)

--- a/openapi_core/schema/parameters/models.py
+++ b/openapi_core/schema/parameters/models.py
@@ -15,7 +15,8 @@ class Parameter(object):
     def __init__(
             self, name, location, schema=None, required=False,
             deprecated=False, allow_empty_value=False,
-            items=None, style=None, explode=None, content=None):
+            items=None, style=None, explode=None, content=None,
+            extensions=None):
         self.name = name
         self.location = ParameterLocation(location)
         self.schema = schema
@@ -31,6 +32,7 @@ class Parameter(object):
         self.style = ParameterStyle(style or self.default_style)
         self.explode = self.default_explode if explode is None else explode
         self.content = content
+        self.extensions = extensions and dict(extensions) or {}
 
     @property
     def aslist(self):


### PR DESCRIPTION
Extensions are allowed on Parameter objects, per the spec:

> This object MAY be extended with Specification Extensions.

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#parameterObject