### PR TITLE
Set license from __init__.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ if __name__ == '__main__':
         author=metadata['author'],
         author_email=metadata['email'],
         url=metadata['url'],
+        license=metadata['license'],
         cmdclass={'test': PyTest},
         setup_cfg=True,
     )


### PR DESCRIPTION
This fixes pip so it displays the correct license for the package.