### PR TITLE
Add link to Tornado integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -135,3 +135,4 @@ Related projects
 * `openapi-spec-validator <https://github.com/p1c2u/openapi-spec-validator>`__
 * `openapi-schema-validator <https://github.com/p1c2u/openapi-schema-validator>`__
 * `pyramid_openapi3 <https://github.com/niteoweb/pyramid_openapi3>`__
+* `tornado-openapi3 <https://github.com/correl/tornado-openapi3>`__

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -196,3 +196,8 @@ You can use RequestsOpenAPIResponse as a Requests response factory:
    openapi_response = RequestsOpenAPIResponse(requests_response)
    validator = ResponseValidator(spec)
    result = validator.validate(openapi_request, openapi_response)
+
+Tornado
+-------
+
+See `tornado-openapi3  <https://github.com/correl/tornado-openapi3>`_ project.


### PR DESCRIPTION
Add a link to the tornado-openapi3 project I authored which provides openapi-core validation for the Tornado web application framework.

- Project: https://github.com/correl/tornado-openapi3
- Documentation: https://tornado-openapi3.readthedocs.io/en/latest/