### PR TITLE
Validators refactor

### DIFF
--- a/openapi_core/__init__.py
+++ b/openapi_core/__init__.py
@@ -1,7 +1,20 @@
 # -*- coding: utf-8 -*-
 """OpenAPI core module"""
 from openapi_core.shortcuts import (
-    create_spec, validate_parameters, validate_body, validate_data,
+    create_spec, validate_request, validate_response,
+    spec_validate_body, spec_validate_parameters, spec_validate_security,
+    spec_validate_data, spec_validate_headers,
+)
+from openapi_core.validation.request.validators import (
+    RequestValidator,
+    RequestBodyValidator,
+    RequestParametersValidator,
+    RequestSecurityValidator,
+)
+from openapi_core.validation.response.validators import (
+    ResponseValidator,
+    ResponseDataValidator,
+    ResponseHeadersValidator,
 )
 
 __author__ = 'Artur Maciag'
@@ -11,5 +24,10 @@ __url__ = 'https://github.com/p1c2u/openapi-core'
 __license__ = 'BSD 3-Clause License'
 
 __all__ = [
-    'create_spec', 'validate_parameters', 'validate_body', 'validate_data',
+    'create_spec', 'validate_request', 'validate_response',
+    'spec_validate_body', 'spec_validate_parameters', 'spec_validate_security',
+    'spec_validate_data', 'spec_validate_headers',
+    'RequestValidator', 'ResponseValidator', 'RequestBodyValidator',
+    'RequestParametersValidator', 'RequestSecurityValidator',
+    'ResponseDataValidator', 'ResponseHeadersValidator',
 ]

--- a/openapi_core/schema/parameters.py
+++ b/openapi_core/schema/parameters.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from itertools import chain
 
 
 def get_aslist(param_or_header):
@@ -52,3 +53,8 @@ def get_value(param_or_header, location, name=None):
         return location.getlist(name)
 
     return location[name]
+
+
+def iter_params(*lists):
+    iters = map(lambda l: l and iter(l) or [], lists)
+    return chain(*iters)

--- a/openapi_core/shortcuts.py
+++ b/openapi_core/shortcuts.py
@@ -2,16 +2,17 @@
 # backward compatibility
 from openapi_core.spec.shortcuts import create_spec
 from openapi_core.validation.request.shortcuts import (
-    spec_validate_body as validate_body,
-    spec_validate_parameters as validate_parameters,
+    validate_request,
+    spec_validate_body, spec_validate_parameters, spec_validate_security,
 )
-from openapi_core.validation.request.validators import RequestValidator
 from openapi_core.validation.response.shortcuts import (
-    spec_validate_data as validate_data
+    validate_response,
+    spec_validate_data, spec_validate_headers,
 )
-from openapi_core.validation.response.validators import ResponseValidator
 
 __all__ = [
-    'create_spec', 'validate_body', 'validate_parameters', 'validate_data',
-    'RequestValidator', 'ResponseValidator',
+    'create_spec',
+    'validate_request', 'validate_response',
+    'spec_validate_body', 'spec_validate_parameters', 'spec_validate_security',
+    'spec_validate_data', 'spec_validate_headers',
 ]

--- a/openapi_core/validation/request/shortcuts.py
+++ b/openapi_core/validation/request/shortcuts.py
@@ -1,57 +1,47 @@
 """OpenAPI core validation request shortcuts module"""
-import warnings
+from functools import partial
 
-from openapi_core.validation.request.validators import RequestValidator
+from openapi_core.validation.request.validators import (
+    RequestValidator,
+    RequestBodyValidator,
+    RequestParametersValidator,
+    RequestSecurityValidator,
+)
 
 
-def validate_request(validator, request, failsafe=None):
-    if failsafe is None:
-        failsafe = ()
+def validate_request(validator, request):
     result = validator.validate(request)
-    try:
-        result.raise_for_errors()
-    except failsafe:
-        pass
-    return result
-
-
-def validate_parameters(validator, request):
-    warnings.warn(
-        "validate_parameters shortcut is deprecated, "
-        "use validator.validate instead",
-        DeprecationWarning,
-    )
-    result = validator._validate_parameters(request)
     result.raise_for_errors()
     return result
 
 
-def validate_body(validator, request):
-    warnings.warn(
-        "validate_body shortcut is deprecated, "
-        "use validator.validate instead",
-        DeprecationWarning,
-    )
-    result = validator._validate_body(request)
+def spec_validate_request(
+    spec, request, request_factory=None, validator_class=RequestValidator,
+    result_attribute=None,
+):
+    if request_factory is not None:
+        request = request_factory(request)
+
+    validator = validator_class(spec)
+
+    result = validator.validate(request)
     result.raise_for_errors()
-    return result
+
+    if result_attribute is None:
+        return result
+    return getattr(result, result_attribute)
 
 
-def spec_validate_parameters(spec, request, request_factory=None):
-    if request_factory is not None:
-        request = request_factory(request)
-
-    validator = RequestValidator(spec)
-    result = validate_parameters(validator, request)
-
-    return result.parameters
+spec_validate_parameters = partial(
+    spec_validate_request,
+    validator_class=RequestParametersValidator, result_attribute='parameters')
 
 
-def spec_validate_body(spec, request, request_factory=None):
-    if request_factory is not None:
-        request = request_factory(request)
+spec_validate_body = partial(
+    spec_validate_request,
+    validator_class=RequestBodyValidator, result_attribute='body')
 
-    validator = RequestValidator(spec)
-    result = validate_body(validator, request)
 
-    return result.body
+spec_validate_security = partial(
+    spec_validate_request,
+    validator_class=RequestSecurityValidator, result_attribute='security')

--- a/openapi_core/validation/request/validators.py
+++ b/openapi_core/validation/request/validators.py
@@ -1,6 +1,5 @@
 """OpenAPI core validation request validators module"""
 from __future__ import division
-from itertools import chain
 import warnings
 
 from openapi_core.casting.schemas.exceptions import CastError
@@ -9,9 +8,9 @@ from openapi_core.exceptions import (
     MissingRequiredParameter, MissingParameter,
     MissingRequiredRequestBody, MissingRequestBody,
 )
+from openapi_core.schema.parameters import iter_params
 from openapi_core.security.exceptions import SecurityError
 from openapi_core.security.factories import SecurityProviderFactory
-from openapi_core.schema.parameters import get_aslist, get_explode
 from openapi_core.templating.media_types.exceptions import MediaTypeFinderError
 from openapi_core.templating.paths.exceptions import PathError
 from openapi_core.unmarshalling.schemas.enums import UnmarshalContext
@@ -28,7 +27,7 @@ from openapi_core.validation.request.datatypes import (
 from openapi_core.validation.validators import BaseValidator
 
 
-class RequestValidator(BaseValidator):
+class BaseRequestValidator(BaseValidator):
 
     @property
     def schema_unmarshallers_factory(self):
@@ -43,109 +42,15 @@ class RequestValidator(BaseValidator):
     def security_provider_factory(self):
         return SecurityProviderFactory()
 
-    def validate(self, request):
-        try:
-            path, operation, _, path_result, _ = self._find_path(request)
-        # don't process if operation errors
-        except PathError as exc:
-            return RequestValidationResult(errors=[exc, ])
-
-        try:
-            security = self._get_security(request, operation)
-        except InvalidSecurity as exc:
-            return RequestValidationResult(errors=[exc, ])
-
-        request.parameters.path = request.parameters.path or \
-            path_result.variables
-
+    def _get_parameters(self, request, path, operation):
         operation_params = operation.get('parameters', [])
-        operation_params_iter = operation_params and \
-            iter(operation_params) or []
         path_params = path.get('parameters', [])
-        params_params_iter = path_params and \
-            iter(path_params) or []
-        params, params_errors = self._get_parameters(
-            request, chain(
-                operation_params_iter,
-                params_params_iter,
-            )
-        )
 
-        body, body_errors = self._get_body(request, operation)
-
-        errors = params_errors + body_errors
-        return RequestValidationResult(
-            errors=errors,
-            body=body,
-            parameters=params,
-            security=security,
-        )
-
-    def _validate_parameters(self, request):
-        try:
-            path, operation, _, path_result, _ = self._find_path(request)
-        except PathError as exc:
-            return RequestValidationResult(errors=[exc, ])
-
-        request.parameters.path = request.parameters.path or \
-            path_result.variables
-
-        operation_params = operation.get('parameters', [])
-        operation_params_iter = operation_params and \
-            iter(operation_params) or []
-        path_params = path.get('parameters', [])
-        params_params_iter = path_params and \
-            iter(path_params) or []
-        params, params_errors = self._get_parameters(
-            request, chain(
-                operation_params_iter,
-                params_params_iter,
-            )
-        )
-        return RequestValidationResult(
-            errors=params_errors,
-            parameters=params,
-        )
-
-    def _validate_body(self, request):
-        try:
-            _, operation, _, _, _ = self._find_path(request)
-        except PathError as exc:
-            return RequestValidationResult(errors=[exc, ])
-
-        body, body_errors = self._get_body(request, operation)
-        return RequestValidationResult(
-            errors=body_errors,
-            body=body,
-        )
-
-    def _get_security(self, request, operation):
-        security = None
-        if 'security' in self.spec:
-            security = self.spec / 'security'
-        if 'security' in operation:
-            security = operation / 'security'
-
-        if not security:
-            return {}
-
-        for security_requirement in security:
-            try:
-                return {
-                    scheme_name: self._get_security_value(
-                        scheme_name, request)
-                    for scheme_name in security_requirement.keys()
-                }
-            except SecurityError:
-                continue
-
-        raise InvalidSecurity()
-
-    def _get_parameters(self, request, params):
         errors = []
         seen = set()
         locations = {}
-        for param in params:
+        params_iter = iter_params(operation_params, path_params)
+        for param in params_iter:
             param_name = param['name']
             param_location = param['in']
             if (param_name, param_location) in seen:
@@ -188,6 +93,36 @@ class RequestValidator(BaseValidator):
                 raise MissingRequiredParameter(name)
             raise MissingParameter(name)
 
+    def _get_security(self, request, operation):
+        security = None
+        if 'security' in self.spec:
+            security = self.spec / 'security'
+        if 'security' in operation:
+            security = operation / 'security'
+
+        if not security:
+            return {}
+
+        for security_requirement in security:
+            try:
+                return {
+                    scheme_name: self._get_security_value(
+                        scheme_name, request)
+                    for scheme_name in security_requirement.keys()
+                }
+            except SecurityError:
+                continue
+
+        raise InvalidSecurity()
+
+    def _get_security_value(self, scheme_name, request):
+        security_schemes = self.spec / 'components#securitySchemes'
+        if scheme_name not in security_schemes:
+            return
+        scheme = security_schemes[scheme_name]
+        security_provider = self.security_provider_factory.create(scheme)
+        return security_provider(request)
+
     def _get_body(self, request, operation):
         if 'requestBody' not in operation:
             return None, []
@@ -228,36 +163,93 @@ class RequestValidator(BaseValidator):
 
         return body, []
 
-    def _get_security_value(self, scheme_name, request):
-        security_schemes = self.spec / 'components#securitySchemes'
-        if scheme_name not in security_schemes:
-            return
-        scheme = security_schemes[scheme_name]
-        security_provider = self.security_provider_factory.create(scheme)
-        return security_provider(request)
-
-    def _get_parameter_value(self, param, request):
-        param_location = param['in']
-        location = request.parameters[param_location]
-
-        if param['name'] not in location:
-            if param.getkey('required', False):
-                raise MissingRequiredParameter(param['name'])
-
-            raise MissingParameter(param['name'])
-
-        aslist = get_aslist(param)
-        explode = get_explode(param)
-        if aslist and explode:
-            if hasattr(location, 'getall'):
-                return location.getall(param['name'])
-            return location.getlist(param['name'])
-
-        return location[param['name']]
-
     def _get_body_value(self, request_body, request):
         if not request.body:
             if request_body.getkey('required', False):
                 raise MissingRequiredRequestBody(request)
             raise MissingRequestBody(request)
         return request.body
+
+
+class RequestParametersValidator(BaseRequestValidator):
+
+    def validate(self, request):
+        try:
+            path, operation, _, path_result, _ = self._find_path(request)
+        except PathError as exc:
+            return RequestValidationResult(errors=[exc, ])
+
+        request.parameters.path = request.parameters.path or \
+            path_result.variables
+
+        params, params_errors = self._get_parameters(request, path, operation)
+
+        return RequestValidationResult(
+            errors=params_errors,
+            parameters=params,
+        )
+
+
+class RequestBodyValidator(BaseRequestValidator):
+
+    def validate(self, request):
+        try:
+            _, operation, _, _, _ = self._find_path(request)
+        except PathError as exc:
+            return RequestValidationResult(errors=[exc, ])
+
+        body, body_errors = self._get_body(request, operation)
+
+        return RequestValidationResult(
+            errors=body_errors,
+            body=body,
+        )
+
+
+class RequestSecurityValidator(BaseRequestValidator):
+
+    def validate(self, request):
+        try:
+            _, operation, _, _, _ = self._find_path(request)
+        except PathError as exc:
+            return RequestValidationResult(errors=[exc, ])
+
+        try:
+            security = self._get_security(request, operation)
+        except InvalidSecurity as exc:
+            return RequestValidationResult(errors=[exc, ])
+
+        return RequestValidationResult(
+            errors=[],
+            security=security,
+        )
+
+
+class RequestValidator(BaseRequestValidator):
+
+    def validate(self, request):
+        try:
+            path, operation, _, path_result, _ = self._find_path(request)
+        # don't process if operation errors
+        except PathError as exc:
+            return RequestValidationResult(errors=[exc, ])
+
+        try:
+            security = self._get_security(request, operation)
+        except InvalidSecurity as exc:
+            return RequestValidationResult(errors=[exc, ])
+
+        request.parameters.path = request.parameters.path or \
+            path_result.variables
+
+        params, params_errors = self._get_parameters(request, path, operation)
+
+        body, body_errors = self._get_body(request, operation)
+
+        errors = params_errors + body_errors
+        return RequestValidationResult(
+            errors=errors,
+            body=body,
+            parameters=params,
+            security=security,
+        )

--- a/tests/integration/validation/test_petstore.py
+++ b/tests/integration/validation/test_petstore.py
@@ -16,7 +16,8 @@ from openapi_core.exceptions import (
     MissingRequiredHeader, MissingRequiredParameter,
 )
 from openapi_core.shortcuts import (
-    create_spec, validate_parameters, validate_body, validate_data,
+    create_spec, spec_validate_parameters, spec_validate_body,
+    spec_validate_security, spec_validate_data, spec_validate_headers,
 )
 from openapi_core.templating.media_types.exceptions import MediaTypeNotFound
 from openapi_core.templating.paths.exceptions import (
@@ -72,8 +73,8 @@ class TestPetstore(object):
         )
 
         with pytest.warns(DeprecationWarning):
-            parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+            parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters(
             query={
@@ -115,8 +116,8 @@ class TestPetstore(object):
             path_pattern=path_pattern, args=query_params,
         )
 
-        parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+        parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters(
             query={
@@ -161,8 +162,8 @@ class TestPetstore(object):
             path_pattern=path_pattern, args=query_params,
         )
 
-        parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+        parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters(
             query={
@@ -193,8 +194,8 @@ class TestPetstore(object):
             path_pattern=path_pattern, args=query_params,
         )
 
-        parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+        parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters(
             query={
@@ -219,7 +220,7 @@ class TestPetstore(object):
         response = MockResponse(response_data)
 
         with pytest.raises(InvalidSchemaValue):
-            validate_data(spec, request, response)
+            spec_validate_data(spec, request, response)
 
         response_result = response_validator.validate(request, response)
 
@@ -246,8 +247,8 @@ class TestPetstore(object):
             path_pattern=path_pattern, args=query_params,
         )
 
-        parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+        parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters(
             query={
@@ -284,8 +285,8 @@ class TestPetstore(object):
             path_pattern=path_pattern, args=query_params,
         )
 
-        parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+        parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters(
             query={
@@ -323,9 +324,9 @@ class TestPetstore(object):
         )
 
         with pytest.raises(DeserializeError):
-            validate_parameters(spec, request)
+            spec_validate_parameters(spec, request)
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert body is None
 
@@ -342,9 +343,9 @@ class TestPetstore(object):
         )
 
         with pytest.raises(CastError):
-            validate_parameters(spec, request)
+            spec_validate_parameters(spec, request)
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert body is None
 
@@ -357,9 +358,9 @@ class TestPetstore(object):
         )
 
         with pytest.raises(MissingRequiredParameter):
-            validate_parameters(spec, request)
+            spec_validate_parameters(spec, request)
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert body is None
 
@@ -376,8 +377,8 @@ class TestPetstore(object):
         )
 
         with pytest.raises(EmptyParameterValue):
-            validate_parameters(spec, request)
-        body = validate_body(spec, request)
+            spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert body is None
 
@@ -395,7 +396,7 @@ class TestPetstore(object):
         )
 
         with pytest.warns(DeprecationWarning):
-            parameters = validate_parameters(spec, request)
+            parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             query={
@@ -405,7 +406,7 @@ class TestPetstore(object):
             }
         )
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert body is None
 
@@ -421,7 +422,7 @@ class TestPetstore(object):
             path_pattern=path_pattern, args=query_params,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             query={
@@ -431,7 +432,7 @@ class TestPetstore(object):
             }
         )
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert body is None
 
@@ -448,7 +449,7 @@ class TestPetstore(object):
             path_pattern=path_pattern, args=query_params,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             query={
@@ -459,7 +460,7 @@ class TestPetstore(object):
             }
         )
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert body is None
 
@@ -480,7 +481,7 @@ class TestPetstore(object):
             path_pattern=path_pattern, args=query_params,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             query={
@@ -491,7 +492,7 @@ class TestPetstore(object):
             }
         )
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert body is None
 
@@ -535,7 +536,7 @@ class TestPetstore(object):
             headers=headers, cookies=cookies,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             header={
@@ -549,7 +550,7 @@ class TestPetstore(object):
             },
         )
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         schemas = spec_dict['components']['schemas']
         pet_model = schemas['PetCreate']['x-model']
@@ -562,6 +563,10 @@ class TestPetstore(object):
         assert body.address.street == pet_street
         assert body.address.city == pet_city
         assert body.healthy == pet_healthy
+
+        security = spec_validate_security(spec, request)
+
+        assert security == {}
 
     def test_post_cats(self, spec, spec_dict):
         host_url = 'https://staging.gigantic-server.com/v1'
@@ -598,7 +603,7 @@ class TestPetstore(object):
             headers=headers, cookies=cookies,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             header={
@@ -609,7 +614,7 @@ class TestPetstore(object):
             },
         )
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         schemas = spec_dict['components']['schemas']
         pet_model = schemas['PetCreate']['x-model']
@@ -658,7 +663,7 @@ class TestPetstore(object):
             headers=headers, cookies=cookies,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             header={
@@ -669,7 +674,7 @@ class TestPetstore(object):
             },
         )
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         schemas = spec_dict['components']['schemas']
         pet_model = schemas['PetCreate']['x-model']
@@ -706,7 +711,7 @@ class TestPetstore(object):
             headers=headers, cookies=cookies,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             header={
@@ -718,7 +723,7 @@ class TestPetstore(object):
         )
 
         with pytest.raises(InvalidSchemaValue):
-            validate_body(spec, request)
+            spec_validate_body(spec, request)
 
     def test_post_cats_only_required_body(self, spec, spec_dict):
         host_url = 'https://staging.gigantic-server.com/v1'
@@ -745,7 +750,7 @@ class TestPetstore(object):
             headers=headers, cookies=cookies,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             header={
@@ -756,7 +761,7 @@ class TestPetstore(object):
             },
         )
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         schemas = spec_dict['components']['schemas']
         pet_model = schemas['PetCreate']['x-model']
@@ -786,7 +791,7 @@ class TestPetstore(object):
             headers=headers, cookies=cookies,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             header={
@@ -798,7 +803,7 @@ class TestPetstore(object):
         )
 
         with pytest.raises(MediaTypeNotFound):
-            validate_body(spec, request)
+            spec_validate_body(spec, request)
 
     def test_post_pets_missing_cookie(self, spec, spec_dict):
         host_url = 'https://staging.gigantic-server.com/v1'
@@ -823,9 +828,9 @@ class TestPetstore(object):
         )
 
         with pytest.raises(MissingRequiredParameter):
-            validate_parameters(spec, request)
+            spec_validate_parameters(spec, request)
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         schemas = spec_dict['components']['schemas']
         pet_model = schemas['PetCreate']['x-model']
@@ -857,9 +862,9 @@ class TestPetstore(object):
         )
 
         with pytest.raises(MissingRequiredParameter):
-            validate_parameters(spec, request)
+            spec_validate_parameters(spec, request)
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         schemas = spec_dict['components']['schemas']
         pet_model = schemas['PetCreate']['x-model']
@@ -890,10 +895,10 @@ class TestPetstore(object):
         )
 
         with pytest.raises(ServerNotFound):
-            validate_parameters(spec, request)
+            spec_validate_parameters(spec, request)
 
         with pytest.raises(ServerNotFound):
-            validate_body(spec, request)
+            spec_validate_body(spec, request)
 
         data_id = 1
         data_name = 'test'
@@ -910,7 +915,7 @@ class TestPetstore(object):
         response = MockResponse(data)
 
         with pytest.raises(ServerNotFound):
-            validate_data(spec, request, response)
+            spec_validate_data(spec, request, response)
 
     def test_get_pet(self, spec, response_validator):
         host_url = 'http://petstore.swagger.io/v1'
@@ -918,12 +923,17 @@ class TestPetstore(object):
         view_args = {
             'petId': '1',
         }
+        auth = 'authuser'
+        headers = {
+            'Authorization': 'Basic {auth}'.format(auth=auth),
+        }
         request = MockRequest(
             host_url, 'GET', '/pets/1',
             path_pattern=path_pattern, view_args=view_args,
+            headers=headers,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             path={
@@ -931,9 +941,15 @@ class TestPetstore(object):
             }
         )
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert body is None
+
+        security = spec_validate_security(spec, request)
+
+        assert security == {
+            'petstore_auth': auth,
+        }
 
         data_id = 1
         data_name = 'test'
@@ -968,7 +984,7 @@ class TestPetstore(object):
             path_pattern=path_pattern, view_args=view_args,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             path={
@@ -976,7 +992,7 @@ class TestPetstore(object):
             }
         )
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert body is None
 
@@ -1010,7 +1026,7 @@ class TestPetstore(object):
             path_pattern=path_pattern, view_args=view_args,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters(
             path={
@@ -1018,7 +1034,7 @@ class TestPetstore(object):
             }
         )
 
-        body = validate_body(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert body is None
 
@@ -1039,8 +1055,8 @@ class TestPetstore(object):
             path_pattern=path_pattern,
         )
 
-        parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+        parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters()
         assert body is None
@@ -1070,12 +1086,12 @@ class TestPetstore(object):
             path_pattern=path_pattern, data=data,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters()
 
         with pytest.raises(InvalidSchemaValue):
-            validate_body(spec, request)
+            spec_validate_body(spec, request)
 
     def test_post_tags_empty_body(self, spec, spec_dict):
         host_url = 'http://petstore.swagger.io/v1'
@@ -1088,12 +1104,12 @@ class TestPetstore(object):
             path_pattern=path_pattern, data=data,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters()
 
         with pytest.raises(InvalidSchemaValue):
-            validate_body(spec, request)
+            spec_validate_body(spec, request)
 
     def test_post_tags_wrong_property_type(self, spec):
         host_url = 'http://petstore.swagger.io/v1'
@@ -1106,12 +1122,12 @@ class TestPetstore(object):
             path_pattern=path_pattern, data=data,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
 
         assert parameters == RequestParameters()
 
         with pytest.raises(InvalidSchemaValue):
-            validate_body(spec, request)
+            spec_validate_body(spec, request)
 
     def test_post_tags_additional_properties(
             self, spec, response_validator):
@@ -1128,8 +1144,8 @@ class TestPetstore(object):
             path_pattern=path_pattern, data=data,
         )
 
-        parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+        parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters()
         assert isinstance(body, BaseModel)
@@ -1174,8 +1190,8 @@ class TestPetstore(object):
             path_pattern=path_pattern, data=data,
         )
 
-        parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+        parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters()
         assert isinstance(body, BaseModel)
@@ -1221,8 +1237,8 @@ class TestPetstore(object):
             path_pattern=path_pattern, data=data,
         )
 
-        parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+        parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters()
         assert isinstance(body, BaseModel)
@@ -1242,7 +1258,7 @@ class TestPetstore(object):
         response_data = json.dumps(response_data_json)
         response = MockResponse(response_data, status_code=404)
 
-        data = validate_data(spec, request, response)
+        data = spec_validate_data(spec, request, response)
 
         assert isinstance(data, BaseModel)
         assert data.code == code
@@ -1276,9 +1292,9 @@ class TestPetstore(object):
             path_pattern=path_pattern, data=data,
         )
 
-        parameters = validate_parameters(spec, request)
+        parameters = spec_validate_parameters(spec, request)
         with pytest.raises(InvalidSchemaValue):
-            validate_body(spec, request)
+            spec_validate_body(spec, request)
 
         assert parameters == RequestParameters()
 
@@ -1320,12 +1336,29 @@ class TestPetstore(object):
             path_pattern=path_pattern, data=data,
         )
 
-        parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+        parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters()
         assert isinstance(body, BaseModel)
         assert body.ids == ids
+
+        data = None
+        headers = {
+            'x-delete-confirm': 'true',
+        }
+        response = MockResponse(data, status_code=200, headers=headers)
+
+        with pytest.warns(DeprecationWarning):
+            response_result = response_validator.validate(request, response)
+        assert response_result.errors == []
+        assert response_result.data is None
+
+        response_headers = spec_validate_headers(spec, request, response)
+
+        assert response_headers == {
+            'x-delete-confirm': True,
+        }
 
     def test_delete_tags_no_requestbody(
             self, spec, response_validator):
@@ -1336,8 +1369,8 @@ class TestPetstore(object):
             path_pattern=path_pattern,
         )
 
-        parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+        parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters()
         assert body is None
@@ -1351,8 +1384,8 @@ class TestPetstore(object):
             path_pattern=path_pattern,
         )
 
-        parameters = validate_parameters(spec, request)
-        body = validate_body(spec, request)
+        parameters = spec_validate_parameters(spec, request)
+        body = spec_validate_body(spec, request)
 
         assert parameters == RequestParameters()
         assert body is None
@@ -1360,8 +1393,7 @@ class TestPetstore(object):
         data = None
         response = MockResponse(data, status_code=200)
 
-        with pytest.warns(DeprecationWarning):
-            response_result = response_validator.validate(request, response)
+        response_result = response_validator.validate(request, response)
         assert response_result.errors == [
             MissingRequiredHeader(name='x-delete-confirm'),
         ]

--- a/tests/unit/validation/test_request_shortcuts.py
+++ b/tests/unit/validation/test_request_shortcuts.py
@@ -12,8 +12,8 @@ from openapi_core.validation.request.shortcuts import (
 class TestSpecValidateParameters(object):
 
     @mock.patch(
-        'openapi_core.validation.request.shortcuts.RequestValidator.'
-        '_validate_parameters'
+        'openapi_core.validation.request.shortcuts.RequestParametersValidator.'
+        'validate'
     )
     def test_no_request_factory(self, mock_validate):
         spec = mock.sentinel.spec
@@ -27,8 +27,8 @@ class TestSpecValidateParameters(object):
         mock_validate.aasert_called_once_with(request)
 
     @mock.patch(
-        'openapi_core.validation.request.shortcuts.RequestValidator.'
-        '_validate_parameters'
+        'openapi_core.validation.request.shortcuts.RequestParametersValidator.'
+        'validate'
     )
     def test_no_request_factory_error(self, mock_validate):
         spec = mock.sentinel.spec
@@ -41,8 +41,8 @@ class TestSpecValidateParameters(object):
         mock_validate.aasert_called_once_with(request)
 
     @mock.patch(
-        'openapi_core.validation.request.shortcuts.RequestValidator.'
-        '_validate_parameters'
+        'openapi_core.validation.request.shortcuts.RequestParametersValidator.'
+        'validate'
     )
     def test_request_factory(self, mock_validate):
         spec = mock.sentinel.spec
@@ -59,8 +59,8 @@ class TestSpecValidateParameters(object):
         )
 
     @mock.patch(
-        'openapi_core.validation.request.shortcuts.RequestValidator.'
-        '_validate_parameters'
+        'openapi_core.validation.request.shortcuts.RequestParametersValidator.'
+        'validate'
     )
     def test_request_factory_error(self, mock_validate):
         spec = mock.sentinel.spec
@@ -79,8 +79,8 @@ class TestSpecValidateParameters(object):
 class TestSpecValidateBody(object):
 
     @mock.patch(
-        'openapi_core.validation.request.shortcuts.RequestValidator.'
-        '_validate_body'
+        'openapi_core.validation.request.shortcuts.RequestBodyValidator.'
+        'validate'
     )
     def test_no_request_factory(self, mock_validate):
         spec = mock.sentinel.spec
@@ -94,8 +94,8 @@ class TestSpecValidateBody(object):
         mock_validate.aasert_called_once_with(request)
 
     @mock.patch(
-        'openapi_core.validation.request.shortcuts.RequestValidator.'
-        '_validate_body'
+        'openapi_core.validation.request.shortcuts.RequestBodyValidator.'
+        'validate'
     )
     def test_no_request_factory_error(self, mock_validate):
         spec = mock.sentinel.spec
@@ -108,8 +108,8 @@ class TestSpecValidateBody(object):
         mock_validate.aasert_called_once_with(request)
 
     @mock.patch(
-        'openapi_core.validation.request.shortcuts.RequestValidator.'
-        '_validate_body'
+        'openapi_core.validation.request.shortcuts.RequestBodyValidator.'
+        'validate'
     )
     def test_request_factory(self, mock_validate):
         spec = mock.sentinel.spec
@@ -126,8 +126,8 @@ class TestSpecValidateBody(object):
         )
 
     @mock.patch(
-        'openapi_core.validation.request.shortcuts.RequestValidator.'
-        '_validate_body'
+        'openapi_core.validation.request.shortcuts.RequestBodyValidator.'
+        'validate'
     )
     def test_request_factory_error(self, mock_validate):
         spec = mock.sentinel.spec

--- a/tests/unit/validation/test_response_shortcuts.py
+++ b/tests/unit/validation/test_response_shortcuts.py
@@ -10,8 +10,8 @@ from openapi_core.validation.response.shortcuts import spec_validate_data
 class TestSpecValidateData(object):
 
     @mock.patch(
-        'openapi_core.validation.response.shortcuts.ResponseValidator.'
-        '_validate_data'
+        'openapi_core.validation.response.shortcuts.ResponseDataValidator.'
+        'validate'
     )
     def test_no_factories(self, mock_validate):
         spec = mock.sentinel.spec
@@ -26,8 +26,8 @@ class TestSpecValidateData(object):
         mock_validate.aasert_called_once_with(request, response)
 
     @mock.patch(
-        'openapi_core.validation.response.shortcuts.ResponseValidator.'
-        '_validate_data'
+        'openapi_core.validation.response.shortcuts.ResponseDataValidator.'
+        'validate'
     )
     def test_no_factories_error(self, mock_validate):
         spec = mock.sentinel.spec
@@ -41,8 +41,8 @@ class TestSpecValidateData(object):
         mock_validate.aasert_called_once_with(request, response)
 
     @mock.patch(
-        'openapi_core.validation.response.shortcuts.ResponseValidator.'
-        '_validate_data'
+        'openapi_core.validation.response.shortcuts.ResponseDataValidator.'
+        'validate'
     )
     def test_factories(self, mock_validate):
         spec = mock.sentinel.spec
@@ -65,8 +65,8 @@ class TestSpecValidateData(object):
         )
 
     @mock.patch(
-        'openapi_core.validation.response.shortcuts.ResponseValidator.'
-        '_validate_data'
+        'openapi_core.validation.response.shortcuts.ResponseDataValidator.'
+        'validate'
     )
     def test_factories_error(self, mock_validate):
         spec = mock.sentinel.spec


### PR DESCRIPTION
Changes
* added `RequestSecurityValidator` and `ResponseHeadersValidator`

Backward incompatibilities
* `validate_parameters`, `validate_body`, `validate_data` shortcuts replaced with `RequestParametersValidator`  `RequestBodyValidator` `ResponseDataValidator` validators