### PR TITLE
Fix  code-block formatting in usage.rst

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -3,6 +3,8 @@ Usage
 
 Firstly create your specification: object
 
+.. code-block:: python
+
    from json import load
    from openapi_core import create_spec
 


### PR DESCRIPTION
Hello.

This code block doesn't look good.
<img width="711" alt="Screenshot 2021-05-21 at 19 54 31" src="https://user-images.githubusercontent.com/12058428/119178738-69da1180-ba6e-11eb-8c8a-0284cd534650.png">

I fixed it.

Love,
Kamil