### PR TITLE
Support basic re_path

### DIFF
--- a/openapi_core/contrib/django/requests.py
+++ b/openapi_core/contrib/django/requests.py
@@ -36,6 +36,11 @@ class DjangoOpenAPIRequestFactory(object):
         else:
             route = cls.path_regex.sub(
                 r'{\1}', request.resolver_match.route)
+            # Delete start marker and expression marker to allow concatenation.
+            if route[:1] == "^":
+                route = route[1:]
+            if route[-1:] == "$":
+                route = route[:-1]
             path_pattern = '/' + route
 
         path = request.resolver_match and request.resolver_match.kwargs or {}

--- a/openapi_core/contrib/django/requests.py
+++ b/openapi_core/contrib/django/requests.py
@@ -36,7 +36,7 @@ class DjangoOpenAPIRequestFactory(object):
         else:
             route = cls.path_regex.sub(
                 r'{\1}', request.resolver_match.route)
-            # Delete start marker and expression marker to allow concatenation.
+            # Delete start and end marker to allow concatenation.
             if route[:1] == "^":
                 route = route[1:]
             if route[-1:] == "$":

--- a/tests/integration/contrib/test_django.py
+++ b/tests/integration/contrib/test_django.py
@@ -44,7 +44,7 @@ class BaseTestDjango(object):
         django.setup()
         settings.ROOT_URLCONF = (
             path('admin/', admin.site.urls),
-            re_path('test/test-regexp/$', lambda d: None)
+            re_path('^test/test-regexp/$', lambda d: None)
         )
 
     @pytest.fixture

--- a/tests/integration/contrib/test_django.py
+++ b/tests/integration/contrib/test_django.py
@@ -19,7 +19,7 @@ class BaseTestDjango(object):
         import django
         from django.conf import settings
         from django.contrib import admin
-        from django.urls import path
+        from django.urls import path, re_path
 
         if settings.configured:
             return
@@ -44,6 +44,7 @@ class BaseTestDjango(object):
         django.setup()
         settings.ROOT_URLCONF = (
             path('admin/', admin.site.urls),
+            re_path('test/test-regexp/$', lambda d: None)
         )
 
     @pytest.fixture
@@ -135,6 +136,31 @@ class TestDjangoOpenAPIRequest(BaseTestDjango):
         assert openapi_request.method == request.method.lower()
         assert openapi_request.full_url_pattern == \
             request._current_scheme_host + "/admin/auth/group/{object_id}/"
+        assert openapi_request.body == request.body
+        assert openapi_request.mimetype == request.content_type
+
+    def test_url_regexp_pattern(self, request_factory):
+        from django.urls import resolve
+        request = request_factory.get('/test/test-regexp/')
+        request.resolver_match = resolve('/test/test-regexp/')
+
+        openapi_request = DjangoOpenAPIRequest(request)
+
+        path = {}
+        query = {}
+        headers = {
+            'Cookie': '',
+        }
+        cookies = {}
+        assert openapi_request.parameters == RequestParameters(
+            path=path,
+            query=query,
+            header=headers,
+            cookie=cookies,
+        )
+        assert openapi_request.method == request.method.lower()
+        assert openapi_request.full_url_pattern == \
+               request._current_scheme_host + "/test/test-regexp/"
         assert openapi_request.body == request.body
         assert openapi_request.mimetype == request.content_type
 


### PR DESCRIPTION
Helllo.

I had a project that used a very old URL format and unfortunately, this library couldn't find the path.
```
from django.conf.urls import url
```
It turned out that this library tries to make various concatenations and matches based on this expression which obviously failed.
https://github.com/p1c2u/openapi-core/blob/512ff6b48d105351c4be730dd78c5d7c00492db1/openapi_core/templating/paths/finders.py#L49

Close: https://github.com/p1c2u/openapi-core/issues/278

Brest regards,
Kamil Breguła