### PR TITLE
Drop python 3.6 support and add support for python 3.10

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 sudo: false
 matrix:
   include:
-  - python: 3.6
   - python: 3.7
   - python: 3.8
   - python: 3.9
+  - python: 3.10
   - python: nightly
   - python: pypy3
   allow_failures:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,16 +25,15 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Software Development :: Libraries"
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
-dataclasses = {version = "*", python = "~3.6"}
+python = "^3.7.0"
 dictpath = "*"
 django = {version = ">=3.0", optional = true}
 falcon = {version = ">=3.0", optional = true}


### PR DESCRIPTION
Updates github action workflow, travis ci and requirements to drop python 3.6 and add python 3.10 support.