### PR TITLE
Add failing test for lists as additional properties

### DIFF
--- a/openapi_core/unmarshalling/schemas/unmarshallers.py
+++ b/openapi_core/unmarshalling/schemas/unmarshallers.py
@@ -181,7 +181,9 @@ class ArrayUnmarshaller(ComplexUnmarshaller):
 
     @property
     def items_unmarshaller(self) -> "BaseSchemaUnmarshaller":
-        return self.unmarshallers_factory.create(self.schema / "items")
+        # sometimes we don't have any schema i.e. free-form objects
+        items_schema = self.schema.get("items", Spec.from_dict({}))
+        return self.unmarshallers_factory.create(items_schema)
 
     def __call__(self, value: Any) -> Optional[List[Any]]:
         value = super().__call__(value)

--- a/tests/unit/unmarshalling/test_unmarshal.py
+++ b/tests/unit/unmarshalling/test_unmarshal.py
@@ -818,9 +818,7 @@ class TestSchemaUnmarshallerCall:
             )
 
     def test_additional_properties_list(self, unmarshaller_factory):
-        schema = {
-            "type": "object"
-        }
+        schema = {"type": "object"}
         spec = Spec.from_dict(schema)
 
         result = unmarshaller_factory(spec, context=UnmarshalContext.RESPONSE)(

--- a/tests/unit/unmarshalling/test_unmarshal.py
+++ b/tests/unit/unmarshalling/test_unmarshal.py
@@ -816,3 +816,16 @@ class TestSchemaUnmarshallerCall:
             unmarshaller_factory(spec, context=UnmarshalContext.RESPONSE)(
                 {"id": 10}
             )
+
+    def test_additional_properties_list(self, unmarshaller_factory):
+        schema = {
+            "type": "object"
+        }
+        spec = Spec.from_dict(schema)
+
+        result = unmarshaller_factory(spec, context=UnmarshalContext.RESPONSE)(
+            {"user_ids": [1, 2, 3, 4]}
+        )
+
+        assert is_dataclass(result)
+        assert result.user_ids == [1, 2, 3, 4]


### PR DESCRIPTION
Upgrading from 0.15.0 to 0.16.0 introduces the following crash when a list is sent as an "additional property" (aka. not part of the OpenAPI spec):

```
self = <jsonschema_spec.accessors.SpecAccessor object at 0x1030d12d0>, content = {}, parts_deque = deque([])

    def _open(
        self, content: Mapping[Hashable, Any], parts_deque: Deque[Hashable]
    ) -> Any:
        if is_ref(content):
            ref = content["$ref"]
            with self.resolver.resolving(ref) as resolved:
                return self._open(resolved, parts_deque)

        try:
            part = parts_deque.popleft()
        except IndexError:
            return content
        else:
>           target = content[part]
E           KeyError: 'items'

content    = {}
part       = 'items'
parts_deque = deque([])
self       = <jsonschema_spec.accessors.SpecAccessor object at 0x1030d12d0>
```

This MR adds a test with a very basic case that reproduces it.