### PR TITLE
Avoid dependency on modern python

### DIFF
--- a/openapi_core/unmarshalling/schemas/factories.py
+++ b/openapi_core/unmarshalling/schemas/factories.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 from typing import Any
 from typing import Dict
@@ -6,7 +7,10 @@ from typing import Optional
 from typing import Type
 from typing import Union
 
-from backports.cached_property import cached_property
+if sys.version_info >= (3, 9):
+    from functools import cached_property
+else:
+    from backports.cached_property import cached_property
 from jsonschema.protocols import Validator
 from openapi_schema_validator import OAS30Validator
 

--- a/openapi_core/unmarshalling/schemas/factories.py
+++ b/openapi_core/unmarshalling/schemas/factories.py
@@ -7,7 +7,7 @@ from typing import Optional
 from typing import Type
 from typing import Union
 
-if sys.version_info >= (3, 9):
+if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
     from backports.cached_property import cached_property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ requests = {version = "*", optional = true}
 werkzeug = "*"
 typing-extensions = "^4.3.0"
 jsonschema-spec = "^0.1.1"
-backports-cached-property = "^1.0.2"
+backports-cached-property = {version = "^1.0.2", python = "<3.9" }
 
 [tool.poetry.extras]
 django = ["django"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ requests = {version = "*", optional = true}
 werkzeug = "*"
 typing-extensions = "^4.3.0"
 jsonschema-spec = "^0.1.1"
-backports-cached-property = {version = "^1.0.2", python = "<3.9" }
+backports-cached-property = {version = "^1.0.2", python = "<3.8" }
 
 [tool.poetry.extras]
 django = ["django"]


### PR DESCRIPTION
Avoid depend on backports.cached_property when the same function is available in functools.