### PR TITLE
Fix PATH_PARAMETER_PATTERN for DRF default value pattern.

### DIFF
--- a/openapi_core/contrib/django/requests.py
+++ b/openapi_core/contrib/django/requests.py
@@ -8,7 +8,7 @@ from werkzeug.datastructures import ImmutableMultiDict
 
 from openapi_core.validation.request.datatypes import RequestParameters
 
-# https://docs.djangoproject.com/en/2.2/topics/http/urls/
+# https://docs.djangoproject.com/en/stable/topics/http/urls/
 #
 # Currently unsupported are :
 #   - nested arguments, e.g.: ^comments/(?:page-(?P<page_number>\d+)/)?$
@@ -16,9 +16,11 @@ from openapi_core.validation.request.datatypes import RequestParameters
 #   - multiple named parameters between a single pair of slashes
 #     e.g.: <page_slug>-<page_id>/edit/
 #
-# The regex matches everything, except a "/" until "<". Than only the name
+# The regex matches everything, except a "/" until "<". Then only the name
 # is exported, after which it matches ">" and everything until a "/".
-PATH_PARAMETER_PATTERN = r"(?:[^\/]*?)<(?:(?:.*?:))*?(\w+)>(?:[^\/]*)"
+# A check is made to ensure that "/" is not in an excluded character set such
+# as may be found with Django REST Framwork's default value pattern, "[^/.]+".
+PATH_PARAMETER_PATTERN = r"(?:[^/]*?)<(?:(?:.*?:))*?(\w+)>(?:(?:[^/]*?\[\^[^/]*/)?[^/]*)"
 
 
 class DjangoOpenAPIRequest:


### PR DESCRIPTION
Django REST Framework will use `[^/.]+` as the default value pattern in certain cases, e.g. `(?P<pk>[^/.]+)`, which doesn't work well with the current regular expression in `PATH_PARAMETER_PATTERN`.

```
❯ git describe; git rev-parse HEAD
3.14.0-69-g0618fa88
0618fa88e1a8c2cf8a2aab29ef6de66b49e5f7ed

❯ git grep -n '\[^/.\]+'
rest_framework/routers.py:143:            self._default_value_pattern = '[^/.]+'
tests/test_routers.py:304:        expected = ['^notes/$', '^notes/(?P<pk>[^/.]+)/$']
tests/test_routers.py:319:        expected = ['^notes$', '^notes/(?P<pk>[^/.]+)$']
```

The fix inserts `(?:[^/]*?\[\^[^/]*/)?` before the final `[^/]*` in the pattern. This allows matching a slash inside an inverted character set, i.e. `[^...]`, treating it as part of the named group.