### PR TITLE
Validation errors refactor

### DIFF
--- a/openapi_core/contrib/django/handlers.py
+++ b/openapi_core/contrib/django/handlers.py
@@ -13,16 +13,14 @@ from openapi_core.templating.media_types.exceptions import MediaTypeNotFound
 from openapi_core.templating.paths.exceptions import OperationNotFound
 from openapi_core.templating.paths.exceptions import PathNotFound
 from openapi_core.templating.paths.exceptions import ServerNotFound
-from openapi_core.validation.exceptions import InvalidSecurity
-from openapi_core.validation.exceptions import MissingRequiredParameter
+from openapi_core.templating.security.exceptions import SecurityNotFound
 
 
 class DjangoOpenAPIErrorsHandler:
 
-    OPENAPI_ERROR_STATUS: Dict[Type[Exception], int] = {
-        MissingRequiredParameter: 400,
+    OPENAPI_ERROR_STATUS: Dict[Type[BaseException], int] = {
         ServerNotFound: 400,
-        InvalidSecurity: 403,
+        SecurityNotFound: 403,
         OperationNotFound: 405,
         PathNotFound: 404,
         MediaTypeNotFound: 415,
@@ -43,7 +41,9 @@ class DjangoOpenAPIErrorsHandler:
         return JsonResponse(data, status=data_error_max["status"])
 
     @classmethod
-    def format_openapi_error(cls, error: Exception) -> Dict[str, Any]:
+    def format_openapi_error(cls, error: BaseException) -> Dict[str, Any]:
+        if error.__cause__ is not None:
+            error = error.__cause__
         return {
             "title": str(error),
             "status": cls.OPENAPI_ERROR_STATUS.get(error.__class__, 400),

--- a/openapi_core/contrib/falcon/handlers.py
+++ b/openapi_core/contrib/falcon/handlers.py
@@ -14,16 +14,14 @@ from openapi_core.templating.media_types.exceptions import MediaTypeNotFound
 from openapi_core.templating.paths.exceptions import OperationNotFound
 from openapi_core.templating.paths.exceptions import PathNotFound
 from openapi_core.templating.paths.exceptions import ServerNotFound
-from openapi_core.validation.exceptions import InvalidSecurity
-from openapi_core.validation.exceptions import MissingRequiredParameter
+from openapi_core.templating.security.exceptions import SecurityNotFound
 
 
 class FalconOpenAPIErrorsHandler:
 
-    OPENAPI_ERROR_STATUS: Dict[Type[Exception], int] = {
-        MissingRequiredParameter: 400,
+    OPENAPI_ERROR_STATUS: Dict[Type[BaseException], int] = {
         ServerNotFound: 400,
-        InvalidSecurity: 403,
+        SecurityNotFound: 403,
         OperationNotFound: 405,
         PathNotFound: 404,
         MediaTypeNotFound: 415,
@@ -49,7 +47,9 @@ class FalconOpenAPIErrorsHandler:
         resp.complete = True
 
     @classmethod
-    def format_openapi_error(cls, error: Exception) -> Dict[str, Any]:
+    def format_openapi_error(cls, error: BaseException) -> Dict[str, Any]:
+        if error.__cause__ is not None:
+            error = error.__cause__
         return {
             "title": str(error),
             "status": cls.OPENAPI_ERROR_STATUS.get(error.__class__, 400),

--- a/openapi_core/contrib/flask/handlers.py
+++ b/openapi_core/contrib/flask/handlers.py
@@ -12,19 +12,21 @@ from openapi_core.templating.media_types.exceptions import MediaTypeNotFound
 from openapi_core.templating.paths.exceptions import OperationNotFound
 from openapi_core.templating.paths.exceptions import PathNotFound
 from openapi_core.templating.paths.exceptions import ServerNotFound
+from openapi_core.templating.security.exceptions import SecurityNotFound
 
 
 class FlaskOpenAPIErrorsHandler:
 
-    OPENAPI_ERROR_STATUS: Dict[Type[Exception], int] = {
+    OPENAPI_ERROR_STATUS: Dict[Type[BaseException], int] = {
         ServerNotFound: 400,
+        SecurityNotFound: 403,
         OperationNotFound: 405,
         PathNotFound: 404,
         MediaTypeNotFound: 415,
     }
 
     @classmethod
-    def handle(cls, errors: Iterable[Exception]) -> Response:
+    def handle(cls, errors: Iterable[BaseException]) -> Response:
         data_errors = [cls.format_openapi_error(err) for err in errors]
         data = {
             "errors": data_errors,
@@ -36,7 +38,9 @@ class FlaskOpenAPIErrorsHandler:
         )
 
     @classmethod
-    def format_openapi_error(cls, error: Exception) -> Dict[str, Any]:
+    def format_openapi_error(cls, error: BaseException) -> Dict[str, Any]:
+        if error.__cause__ is not None:
+            error = error.__cause__
         return {
             "title": str(error),
             "status": cls.OPENAPI_ERROR_STATUS.get(error.__class__, 400),

--- a/openapi_core/security/exceptions.py
+++ b/openapi_core/security/exceptions.py
@@ -1,5 +1,5 @@
 from openapi_core.exceptions import OpenAPIError
 
 
-class SecurityError(OpenAPIError):
+class SecurityProviderError(OpenAPIError):
     pass

--- a/openapi_core/security/providers.py
+++ b/openapi_core/security/providers.py
@@ -1,7 +1,7 @@
 import warnings
 from typing import Any
 
-from openapi_core.security.exceptions import SecurityError
+from openapi_core.security.exceptions import SecurityProviderError
 from openapi_core.spec import Spec
 from openapi_core.validation.request.datatypes import RequestParameters
 
@@ -25,22 +25,26 @@ class ApiKeyProvider(BaseProvider):
         location = self.scheme["in"]
         source = getattr(parameters, location)
         if name not in source:
-            raise SecurityError("Missing api key parameter.")
+            raise SecurityProviderError("Missing api key parameter.")
         return source[name]
 
 
 class HttpProvider(BaseProvider):
     def __call__(self, parameters: RequestParameters) -> Any:
         if "Authorization" not in parameters.header:
-            raise SecurityError("Missing authorization header.")
+            raise SecurityProviderError("Missing authorization header.")
         auth_header = parameters.header["Authorization"]
         try:
             auth_type, encoded_credentials = auth_header.split(" ", 1)
         except ValueError:
-            raise SecurityError("Could not parse authorization header.")
+            raise SecurityProviderError(
+                "Could not parse authorization header."
+            )
 
         scheme = self.scheme["scheme"]
         if auth_type.lower() != scheme:
-            raise SecurityError(f"Unknown authorization method {auth_type}")
+            raise SecurityProviderError(
+                f"Unknown authorization method {auth_type}"
+            )
 
         return encoded_credentials

--- a/openapi_core/templating/security/exceptions.py
+++ b/openapi_core/templating/security/exceptions.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import List
+
+from openapi_core.exceptions import OpenAPIError
+
+
+class SecurityFinderError(OpenAPIError):
+    """Security finder error"""
+
+
+@dataclass
+class SecurityNotFound(SecurityFinderError):
+    """Find security error"""
+
+    schemes: List[List[str]]
+
+    def __str__(self) -> str:
+        return f"Security not found. Schemes not valid for any requirement: {str(self.schemes)}"

--- a/openapi_core/validation/datatypes.py
+++ b/openapi_core/validation/datatypes.py
@@ -2,10 +2,12 @@
 from dataclasses import dataclass
 from typing import Iterable
 
+from openapi_core.exceptions import OpenAPIError
+
 
 @dataclass
 class BaseValidationResult:
-    errors: Iterable[Exception]
+    errors: Iterable[OpenAPIError]
 
     def raise_for_errors(self) -> None:
         for error in self.errors:

--- a/openapi_core/validation/decorators.py
+++ b/openapi_core/validation/decorators.py
@@ -1,0 +1,58 @@
+from functools import wraps
+from inspect import signature
+from typing import Any
+from typing import Callable
+from typing import Optional
+from typing import Type
+
+from openapi_core.exceptions import OpenAPIError
+from openapi_core.unmarshalling.schemas.exceptions import ValidateError
+
+OpenAPIErrorType = Type[OpenAPIError]
+
+
+class ValidationErrorWrapper:
+    def __init__(
+        self,
+        err_cls: OpenAPIErrorType,
+        err_validate_cls: Optional[OpenAPIErrorType] = None,
+        err_cls_init: Optional[str] = None,
+        **err_cls_kw: Any
+    ):
+        self.err_cls = err_cls
+        self.err_validate_cls = err_validate_cls or err_cls
+        self.err_cls_init = err_cls_init
+        self.err_cls_kw = err_cls_kw
+
+    def __call__(self, f: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(f)
+        def wrapper(*args: Any, **kwds: Any) -> Any:
+            try:
+                return f(*args, **kwds)
+            except ValidateError as exc:
+                self._raise_error(exc, self.err_validate_cls, f, *args, **kwds)
+            except OpenAPIError as exc:
+                self._raise_error(exc, self.err_cls, f, *args, **kwds)
+
+        return wrapper
+
+    def _raise_error(
+        self,
+        exc: OpenAPIError,
+        cls: OpenAPIErrorType,
+        f: Callable[..., Any],
+        *args: Any,
+        **kwds: Any
+    ) -> None:
+        if isinstance(exc, self.err_cls):
+            raise
+        sig = signature(f)
+        ba = sig.bind(*args, **kwds)
+        kw = {
+            name: ba.arguments[func_kw]
+            for name, func_kw in self.err_cls_kw.items()
+        }
+        init = cls
+        if self.err_cls_init is not None:
+            init = getattr(cls, self.err_cls_init)
+        raise init(**kw) from exc

--- a/openapi_core/validation/exceptions.py
+++ b/openapi_core/validation/exceptions.py
@@ -8,59 +8,7 @@ class ValidatorDetectError(OpenAPIError):
     pass
 
 
+@dataclass
 class ValidationError(OpenAPIError):
-    pass
-
-
-@dataclass
-class InvalidSecurity(ValidationError):
     def __str__(self) -> str:
-        return "Security not valid for any requirement"
-
-
-class OpenAPIParameterError(OpenAPIError):
-    pass
-
-
-class MissingParameterError(OpenAPIParameterError):
-    """Missing parameter error"""
-
-
-@dataclass
-class MissingParameter(MissingParameterError):
-    name: str
-
-    def __str__(self) -> str:
-        return f"Missing parameter (without default value): {self.name}"
-
-
-@dataclass
-class MissingRequiredParameter(MissingParameterError):
-    name: str
-
-    def __str__(self) -> str:
-        return f"Missing required parameter: {self.name}"
-
-
-class OpenAPIHeaderError(OpenAPIError):
-    pass
-
-
-class MissingHeaderError(OpenAPIHeaderError):
-    """Missing header error"""
-
-
-@dataclass
-class MissingHeader(MissingHeaderError):
-    name: str
-
-    def __str__(self) -> str:
-        return f"Missing header (without default value): {self.name}"
-
-
-@dataclass
-class MissingRequiredHeader(MissingHeaderError):
-    name: str
-
-    def __str__(self) -> str:
-        return f"Missing required header: {self.name}"
+        return f"{self.__class__.__name__}: {self.__cause__}"

--- a/openapi_core/validation/request/exceptions.py
+++ b/openapi_core/validation/request/exceptions.py
@@ -3,17 +3,19 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from openapi_core.exceptions import OpenAPIError
+from openapi_core.spec import Spec
+from openapi_core.unmarshalling.schemas.exceptions import ValidateError
+from openapi_core.validation.exceptions import ValidationError
 from openapi_core.validation.request.datatypes import Parameters
-from openapi_core.validation.request.protocols import Request
 
 
 @dataclass
 class ParametersError(Exception):
     parameters: Parameters
-    errors: Iterable[Exception]
+    errors: Iterable[OpenAPIError]
 
     @property
-    def context(self) -> Iterable[Exception]:
+    def context(self) -> Iterable[OpenAPIError]:
         warnings.warn(
             "context property of ParametersError is deprecated. "
             "Use errors instead.",
@@ -22,11 +24,20 @@ class ParametersError(Exception):
         return self.errors
 
 
-class OpenAPIRequestBodyError(OpenAPIError):
-    pass
+class RequestError(ValidationError):
+    """Request error"""
 
 
-class MissingRequestBodyError(OpenAPIRequestBodyError):
+class RequestBodyError(RequestError):
+    def __str__(self) -> str:
+        return "Request body error"
+
+
+class InvalidRequestBody(RequestBodyError, ValidateError):
+    """Invalid request body"""
+
+
+class MissingRequestBodyError(RequestBodyError):
     """Missing request body error"""
 
 
@@ -38,3 +49,43 @@ class MissingRequestBody(MissingRequestBodyError):
 class MissingRequiredRequestBody(MissingRequestBodyError):
     def __str__(self) -> str:
         return "Missing required request body"
+
+
+@dataclass
+class ParameterError(RequestError):
+    name: str
+    location: str
+
+    @classmethod
+    def from_spec(cls, spec: Spec) -> "ParameterError":
+        return cls(spec["name"], spec["in"])
+
+    def __str__(self) -> str:
+        return f"{self.location.title()} parameter error: {self.name}"
+
+
+class InvalidParameter(ParameterError, ValidateError):
+    def __str__(self) -> str:
+        return f"Invalid {self.location} parameter: {self.name}"
+
+
+class MissingParameterError(ParameterError):
+    """Missing parameter error"""
+
+
+class MissingParameter(MissingParameterError):
+    def __str__(self) -> str:
+        return f"Missing {self.location} parameter: {self.name}"
+
+
+class MissingRequiredParameter(MissingParameterError):
+    def __str__(self) -> str:
+        return f"Missing required {self.location} parameter: {self.name}"
+
+
+class SecurityError(RequestError):
+    pass
+
+
+class InvalidSecurity(SecurityError, ValidateError):
+    """Invalid security"""

--- a/openapi_core/validation/response/exceptions.py
+++ b/openapi_core/validation/response/exceptions.py
@@ -4,7 +4,8 @@ from typing import Dict
 from typing import Iterable
 
 from openapi_core.exceptions import OpenAPIError
-from openapi_core.validation.response.protocols import Response
+from openapi_core.unmarshalling.schemas.exceptions import ValidateError
+from openapi_core.validation.exceptions import ValidationError
 
 
 @dataclass
@@ -13,10 +14,41 @@ class HeadersError(Exception):
     context: Iterable[OpenAPIError]
 
 
-class OpenAPIResponseError(OpenAPIError):
-    pass
+class ResponseError(ValidationError):
+    """Response error"""
 
 
-class MissingResponseContent(OpenAPIResponseError):
+class DataError(ResponseError):
+    """Data error"""
+
+
+class InvalidData(DataError, ValidateError):
+    """Invalid data"""
+
+
+class MissingData(DataError):
     def __str__(self) -> str:
-        return "Missing response content"
+        return "Missing response data"
+
+
+@dataclass
+class HeaderError(ResponseError):
+    name: str
+
+
+class InvalidHeader(HeaderError, ValidateError):
+    """Invalid header"""
+
+
+class MissingHeaderError(HeaderError):
+    """Missing header error"""
+
+
+class MissingHeader(MissingHeaderError):
+    def __str__(self) -> str:
+        return f"Missing header (without default value): {self.name}"
+
+
+class MissingRequiredHeader(MissingHeaderError):
+    def __str__(self) -> str:
+        return f"Missing required header: {self.name}"

--- a/tests/integration/contrib/django/test_django_project.py
+++ b/tests/integration/contrib/django/test_django_project.py
@@ -55,11 +55,11 @@ class TestPetListView(BaseTestDjangoProject):
             "errors": [
                 {
                     "type": (
-                        "<class 'openapi_core.validation.exceptions."
+                        "<class 'openapi_core.validation.request.exceptions."
                         "MissingRequiredParameter'>"
                     ),
                     "status": 400,
-                    "title": "Missing required parameter: limit",
+                    "title": "Missing required query parameter: limit",
                 }
             ]
         }
@@ -149,11 +149,11 @@ class TestPetListView(BaseTestDjangoProject):
             "errors": [
                 {
                     "type": (
-                        "<class 'openapi_core.validation.exceptions."
+                        "<class 'openapi_core.validation.request.exceptions."
                         "MissingRequiredParameter'>"
                     ),
                     "status": 400,
-                    "title": "Missing required parameter: api-key",
+                    "title": "Missing required header parameter: api-key",
                 }
             ]
         }
@@ -214,11 +214,11 @@ class TestPetListView(BaseTestDjangoProject):
             "errors": [
                 {
                     "type": (
-                        "<class 'openapi_core.validation.exceptions."
+                        "<class 'openapi_core.validation.request.exceptions."
                         "MissingRequiredParameter'>"
                     ),
                     "status": 400,
-                    "title": "Missing required parameter: user",
+                    "title": "Missing required cookie parameter: user",
                 }
             ]
         }
@@ -280,11 +280,14 @@ class TestPetDetailView(BaseTestDjangoProject):
             "errors": [
                 {
                     "type": (
-                        "<class 'openapi_core.validation.exceptions."
-                        "InvalidSecurity'>"
+                        "<class 'openapi_core.templating.security.exceptions."
+                        "SecurityNotFound'>"
                     ),
                     "status": 403,
-                    "title": "Security not valid for any requirement",
+                    "title": (
+                        "Security not found. Schemes not valid for any "
+                        "requirement: [['petstore_auth']]"
+                    ),
                 }
             ]
         }

--- a/tests/integration/contrib/falcon/test_falcon_project.py
+++ b/tests/integration/contrib/falcon/test_falcon_project.py
@@ -27,7 +27,20 @@ class TestPetListResource(BaseTestFalconProject):
                 "/v1/pets", host="petstore.swagger.io", headers=headers
             )
 
+        expected_data = {
+            "errors": [
+                {
+                    "type": (
+                        "<class 'openapi_core.validation.request.exceptions."
+                        "MissingRequiredParameter'>"
+                    ),
+                    "status": 400,
+                    "title": "Missing required query parameter: limit",
+                }
+            ]
+        }
         assert response.status_code == 400
+        assert response.json == expected_data
 
     def test_get_valid(self, client):
         headers = {
@@ -120,11 +133,11 @@ class TestPetListResource(BaseTestFalconProject):
             "errors": [
                 {
                     "type": (
-                        "<class 'openapi_core.validation.exceptions."
+                        "<class 'openapi_core.validation.request.exceptions."
                         "MissingRequiredParameter'>"
                     ),
                     "status": 400,
-                    "title": "Missing required parameter: api-key",
+                    "title": "Missing required header parameter: api-key",
                 }
             ]
         }
@@ -199,11 +212,11 @@ class TestPetListResource(BaseTestFalconProject):
             "errors": [
                 {
                     "type": (
-                        "<class 'openapi_core.validation.exceptions."
+                        "<class 'openapi_core.validation.request.exceptions."
                         "MissingRequiredParameter'>"
                     ),
                     "status": 400,
-                    "title": "Missing required parameter: user",
+                    "title": "Missing required cookie parameter: user",
                 }
             ]
         }
@@ -296,11 +309,14 @@ class TestPetDetailResource:
             "errors": [
                 {
                     "type": (
-                        "<class 'openapi_core.validation.exceptions."
-                        "InvalidSecurity'>"
+                        "<class 'openapi_core.templating.security.exceptions."
+                        "SecurityNotFound'>"
                     ),
                     "status": 403,
-                    "title": "Security not valid for any requirement",
+                    "title": (
+                        "Security not found. Schemes not valid for any "
+                        "requirement: [['petstore_auth']]"
+                    ),
                 }
             ]
         }

--- a/tests/integration/contrib/flask/test_flask_views.py
+++ b/tests/integration/contrib/flask/test_flask_views.py
@@ -171,7 +171,7 @@ class TestFlaskOpenAPIView:
             "errors": [
                 {
                     "class": (
-                        "<class 'openapi_core.validation.exceptions."
+                        "<class 'openapi_core.validation.response.exceptions."
                         "MissingRequiredHeader'>"
                     ),
                     "status": 400,

--- a/tests/integration/data/v3.0/petstore.yaml
+++ b/tests/integration/data/v3.0/petstore.yaml
@@ -228,6 +228,11 @@ paths:
               schema:
                 type: boolean
               required: true
+            x-delete-date:
+              description: Confirmation automation date
+              schema:
+                type: string
+                format: date
         default:
           $ref: "#/components/responses/ErrorResponse"
 components:

--- a/tests/integration/validation/test_read_only_write_only.py
+++ b/tests/integration/validation/test_read_only_write_only.py
@@ -7,7 +7,8 @@ from openapi_core import openapi_v30_request_validator
 from openapi_core import openapi_v30_response_validator
 from openapi_core.testing import MockRequest
 from openapi_core.testing import MockResponse
-from openapi_core.unmarshalling.schemas.exceptions import InvalidSchemaValue
+from openapi_core.validation.request.exceptions import InvalidRequestBody
+from openapi_core.validation.response.exceptions import InvalidData
 
 
 @pytest.fixture(scope="class")
@@ -30,7 +31,8 @@ class TestReadOnly:
 
         result = openapi_v30_request_validator.validate(spec, request)
 
-        assert type(result.errors[0]) == InvalidSchemaValue
+        assert len(result.errors) == 1
+        assert type(result.errors[0]) == InvalidRequestBody
         assert result.body is None
 
     def test_read_only_property_response(self, spec):
@@ -93,5 +95,5 @@ class TestWriteOnly:
             spec, request, response
         )
 
-        assert type(result.errors[0]) == InvalidSchemaValue
+        assert result.errors == [InvalidData()]
         assert result.data is None

--- a/tests/integration/validation/test_security_override.py
+++ b/tests/integration/validation/test_security_override.py
@@ -3,8 +3,9 @@ from base64 import b64encode
 import pytest
 
 from openapi_core import openapi_request_validator
+from openapi_core.templating.security.exceptions import SecurityNotFound
 from openapi_core.testing import MockRequest
-from openapi_core.validation.exceptions import InvalidSecurity
+from openapi_core.validation.request.exceptions import SecurityError
 
 
 @pytest.fixture(scope="class")
@@ -40,7 +41,9 @@ class TestSecurityOverride:
 
         result = openapi_request_validator.validate(spec, request)
 
-        assert type(result.errors[0]) == InvalidSecurity
+        assert len(result.errors) == 1
+        assert type(result.errors[0]) is SecurityError
+        assert type(result.errors[0].__cause__) is SecurityNotFound
         assert result.security is None
 
     def test_override(self, spec):
@@ -64,7 +67,9 @@ class TestSecurityOverride:
 
         result = openapi_request_validator.validate(spec, request)
 
-        assert type(result.errors[0]) == InvalidSecurity
+        assert len(result.errors) == 1
+        assert type(result.errors[0]) is SecurityError
+        assert type(result.errors[0].__cause__) is SecurityNotFound
         assert result.security is None
 
     def test_remove(self, spec):


### PR DESCRIPTION
Fixes #246

* All validation exceptions are subclasses of `ValidationError`
* All schema validation exceptions are subclass of `ValidateError`
* All request validation exceptions are subclass of `RequestError`
* All response validation exceptions are subclass of `ResponseError`
* `ParameterError` exceptions have name and location values.
* `HeaderError` exceptions have name value.

Backward compatibilities:
* Schema unmarshalling/validation returns `Invalid*` exception (`InvalidData`, `InvalidParameter`, `InvalidRequestBody`, `InvalidHeader`). Use `__cause__` property to get root cause exception.
* `InvalidSecurity` exception renamed to `SecurityNotFound`