### PR TITLE
Keep empty values when deserializing application/x-www-form-urlencoded

### DIFF
--- a/openapi_core/deserializing/media_types/util.py
+++ b/openapi_core/deserializing/media_types/util.py
@@ -44,7 +44,9 @@ def urlencoded_form_loads(
     value: bytes, **parameters: str
 ) -> Mapping[str, Any]:
     # only UTF-8 is conforming
-    return ImmutableMultiDict(parse_qsl(value.decode("utf-8")))
+    return ImmutableMultiDict(
+        parse_qsl(value.decode("utf-8"), keep_blank_values=True)
+    )
 
 
 def data_form_loads(value: bytes, **parameters: str) -> Mapping[str, Any]:

--- a/tests/unit/deserializing/test_media_types_deserializers.py
+++ b/tests/unit/deserializing/test_media_types_deserializers.py
@@ -201,6 +201,24 @@ class TestMediaTypeDeserializer:
 
         assert result == {}
 
+    def test_urlencoded_form_empty_value(self, deserializer_factory):
+        mimetype = "application/x-www-form-urlencoded"
+        schema_dict = {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                },
+            },
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        deserializer = deserializer_factory(mimetype, schema=schema)
+        value = b"name="
+
+        result = deserializer.deserialize(value)
+
+        assert result == {"name": ""}
+
     def test_urlencoded_form_simple(self, deserializer_factory):
         mimetype = "application/x-www-form-urlencoded"
         schema_dict = {


### PR DESCRIPTION
In order to correctly deserialize the application/x-www-form-urlencoded body `name=` into `{"name": ""}` rather than `{}`, we need to use the [`keep_blank_values=True` parameter of `urllib.parse.parse_qsl`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.parse_qsl).