### PR TITLE
Support aioitertools 0.13

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -118,23 +118,19 @@ speedups = ["Brotli ; platform_python_implementation == \"CPython\"", "aiodns (>
 
 [[package]]
 name = "aioitertools"
-version = "0.12.0"
+version = "0.13.0"
 description = "itertools and builtins for AsyncIO and mixed iterables"
 optional = true
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"starlette\""
 files = [
-    {file = "aioitertools-0.12.0-py3-none-any.whl", hash = "sha256:fc1f5fac3d737354de8831cbba3eb04f79dd649d8f3afb4c5b114925e662a796"},
-    {file = "aioitertools-0.12.0.tar.gz", hash = "sha256:c2a9055b4fbb7705f561b9d86053e8af5d10cc845d22c32008c43490b2d8dd6b"},
+    {file = "aioitertools-0.13.0-py3-none-any.whl", hash = "sha256:0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be"},
+    {file = "aioitertools-0.13.0.tar.gz", hash = "sha256:620bd241acc0bbb9ec819f1ab215866871b4bbd1f73836a55f799200ee86950c"},
 ]
 
 [package.dependencies]
 typing_extensions = {version = ">=4.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-dev = ["attribution (==1.8.0)", "black (==24.8.0)", "build (>=1.2)", "coverage (==7.6.1)", "flake8 (==7.1.1)", "flit (==3.9.0)", "mypy (==1.11.2)", "ufmt (==2.7.1)", "usort (==1.0.8.post1)"]
-docs = ["sphinx (==8.0.2)", "sphinx-mdinclude (==0.6.2)"]
 
 [[package]]
 name = "aiosignal"
@@ -2892,4 +2888,4 @@ starlette = ["aioitertools", "starlette"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9.0"
-content-hash = "e32bb63ea7f2330067585834d57d706df2e54ebde1040c59bd510828b6d4ea39"
+content-hash = "287650d1fb98d6fd28037cbc1ec88e2c7cb714237e8379ca01a092d247538c6b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ werkzeug = ">=2.1.0"
 jsonschema-path = "^0.3.4"
 jsonschema = "^4.23.0"
 multidict = {version = "^6.0.4", optional = true}
-aioitertools = {version = ">=0.11,<0.13", optional = true}
+aioitertools = {version = ">=0.11,<0.14", optional = true}
 fastapi = {version = ">=0.111,<0.116", optional = true}
 typing-extensions = "^4.8.0"
 


### PR DESCRIPTION
First update `rpds-py` in `poetry.lock` so we can resolve dependencies for Python 3.14.

Then expand the version range for `aioitertools` to `">=0.11,<0.14"` and run `poetry update aioitertools`.