### PR TITLE
Typed style deserializers

### DIFF
--- a/openapi_core/casting/schemas/casters.py
+++ b/openapi_core/casting/schemas/casters.py
@@ -1,7 +1,6 @@
 from typing import Any
 from typing import Generic
 from typing import Iterable
-from typing import List
 from typing import Mapping
 from typing import Optional
 from typing import Type
@@ -28,6 +27,14 @@ class PrimitiveCaster:
         self.schema_caster = schema_caster
 
     def __call__(self, value: Any) -> Any:
+        self.validate(value)
+
+        return self.cast(value)
+
+    def validate(self, value: Any) -> None:
+        pass
+
+    def cast(self, value: Any) -> Any:
         return value
 
 
@@ -37,17 +44,8 @@ PrimitiveType = TypeVar("PrimitiveType")
 class PrimitiveTypeCaster(Generic[PrimitiveType], PrimitiveCaster):
     primitive_type: Type[PrimitiveType] = NotImplemented
 
-    def __call__(self, value: Union[str, bytes]) -> Any:
-        self.validate(value)
-
+    def cast(self, value: Union[str, bytes]) -> PrimitiveType:
         return self.primitive_type(value)  # type: ignore [call-arg]
-
-    def validate(self, value: Any) -> None:
-        # FIXME: don't cast data from media type deserializer
-        # See https://github.com/python-openapi/openapi-core/issues/706
-        # if not isinstance(value, (str, bytes)):
-        #     raise ValueError("should cast only from string or bytes")
-        pass
 
 
 class IntegerCaster(PrimitiveTypeCaster[int]):
@@ -61,21 +59,17 @@ class NumberCaster(PrimitiveTypeCaster[float]):
 class BooleanCaster(PrimitiveTypeCaster[bool]):
     primitive_type = bool
 
-    def __call__(self, value: Union[str, bytes]) -> Any:
-        self.validate(value)
-
-        return self.primitive_type(forcebool(value))
-
     def validate(self, value: Any) -> None:
         super().validate(value)
 
-        # FIXME: don't cast data from media type deserializer
-        # See https://github.com/python-openapi/openapi-core/issues/706
         if isinstance(value, bool):
             return
 
         if value.lower() not in ["false", "true"]:
             raise ValueError("not a boolean format")
+
+    def cast(self, value: Union[str, bytes]) -> bool:
+        return self.primitive_type(forcebool(value))
 
 
 class ArrayCaster(PrimitiveCaster):
@@ -85,19 +79,21 @@ class ArrayCaster(PrimitiveCaster):
         items_schema = self.schema.get("items", SchemaPath.from_dict({}))
         return self.schema_caster.evolve(items_schema)
 
-    def __call__(self, value: Any) -> List[Any]:
+    def validate(self, value: Any) -> None:
         # str and bytes are not arrays according to the OpenAPI spec
         if isinstance(value, (str, bytes)) or not isinstance(value, Iterable):
-            raise CastError(value, self.schema["type"])
+            raise ValueError("not an array format")
 
-        try:
-            return list(map(self.items_caster.cast, value))
-        except (ValueError, TypeError):
-            raise CastError(value, self.schema["type"])
+    def cast(self, value: list[Any]) -> list[Any]:
+        return list(map(self.items_caster.cast, value))
 
 
 class ObjectCaster(PrimitiveCaster):
-    def __call__(self, value: Any) -> Any:
+    def validate(self, value: Any) -> None:
+        if not isinstance(value, dict):
+            raise ValueError("not an object format")
+
+    def cast(self, value: dict[str, Any]) -> dict[str, Any]:
         return self._cast_proparties(value)
 
     def evolve(self, schema: SchemaPath) -> "ObjectCaster":
@@ -109,9 +105,11 @@ class ObjectCaster(PrimitiveCaster):
             self.schema_caster.evolve(schema),
         )
 
-    def _cast_proparties(self, value: Any, schema_only: bool = False) -> Any:
+    def _cast_proparties(
+        self, value: dict[str, Any], schema_only: bool = False
+    ) -> dict[str, Any]:
         if not isinstance(value, dict):
-            raise CastError(value, self.schema["type"])
+            raise ValueError("not an object format")
 
         all_of_schemas = self.schema_validator.iter_all_of_schemas(value)
         for all_of_schema in all_of_schemas:

--- a/openapi_core/casting/schemas/datatypes.py
+++ b/openapi_core/casting/schemas/datatypes.py
@@ -1,4 +1,0 @@
-from typing import Any
-from typing import Callable
-
-CasterCallable = Callable[[Any], Any]

--- a/openapi_core/casting/schemas/exceptions.py
+++ b/openapi_core/casting/schemas/exceptions.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 from typing import Any
 
-from openapi_core.exceptions import OpenAPIError
+from openapi_core.deserializing.exceptions import DeserializeError
 
 
 @dataclass
-class CastError(OpenAPIError):
+class CastError(DeserializeError):
     """Schema cast operation error"""
 
     value: Any

--- a/openapi_core/deserializing/media_types/__init__.py
+++ b/openapi_core/deserializing/media_types/__init__.py
@@ -12,9 +12,8 @@ from openapi_core.deserializing.media_types.util import json_loads
 from openapi_core.deserializing.media_types.util import plain_loads
 from openapi_core.deserializing.media_types.util import urlencoded_form_loads
 from openapi_core.deserializing.media_types.util import xml_loads
-from openapi_core.deserializing.styles import style_deserializers_factory
 
-__all__ = ["media_type_deserializers_factory"]
+__all__ = ["media_type_deserializers", "MediaTypeDeserializersFactory"]
 
 media_type_deserializers: MediaTypeDeserializersDict = defaultdict(
     lambda: binary_loads,
@@ -29,9 +28,4 @@ media_type_deserializers: MediaTypeDeserializersDict = defaultdict(
         "application/x-www-form-urlencoded": urlencoded_form_loads,
         "multipart/form-data": data_form_loads,
     }
-)
-
-media_type_deserializers_factory = MediaTypeDeserializersFactory(
-    style_deserializers_factory,
-    media_type_deserializers=media_type_deserializers,
 )

--- a/openapi_core/deserializing/media_types/factories.py
+++ b/openapi_core/deserializing/media_types/factories.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from jsonschema_path import SchemaPath
 
+from openapi_core.casting.schemas.factories import SchemaCastersFactory
 from openapi_core.deserializing.media_types.datatypes import (
     MediaTypeDeserializersDict,
 )
@@ -12,6 +13,7 @@ from openapi_core.deserializing.media_types.deserializers import (
 from openapi_core.deserializing.media_types.deserializers import (
     MediaTypesDeserializer,
 )
+from openapi_core.deserializing.styles.datatypes import StyleDeserializersDict
 from openapi_core.deserializing.styles.factories import (
     StyleDeserializersFactory,
 )
@@ -27,6 +29,31 @@ class MediaTypeDeserializersFactory:
         if media_type_deserializers is None:
             media_type_deserializers = {}
         self.media_type_deserializers = media_type_deserializers
+
+    @classmethod
+    def from_schema_casters_factory(
+        cls,
+        schema_casters_factory: SchemaCastersFactory,
+        style_deserializers: Optional[StyleDeserializersDict] = None,
+        media_type_deserializers: Optional[MediaTypeDeserializersDict] = None,
+    ) -> "MediaTypeDeserializersFactory":
+        from openapi_core.deserializing.media_types import (
+            media_type_deserializers as default_media_type_deserializers,
+        )
+        from openapi_core.deserializing.styles import (
+            style_deserializers as default_style_deserializers,
+        )
+
+        style_deserializers_factory = StyleDeserializersFactory(
+            schema_casters_factory,
+            style_deserializers=style_deserializers
+            or default_style_deserializers,
+        )
+        return cls(
+            style_deserializers_factory,
+            media_type_deserializers=media_type_deserializers
+            or default_media_type_deserializers,
+        )
 
     def create(
         self,

--- a/openapi_core/deserializing/styles/__init__.py
+++ b/openapi_core/deserializing/styles/__init__.py
@@ -10,7 +10,7 @@ from openapi_core.deserializing.styles.util import pipe_delimited_loads
 from openapi_core.deserializing.styles.util import simple_loads
 from openapi_core.deserializing.styles.util import space_delimited_loads
 
-__all__ = ["style_deserializers_factory"]
+__all__ = ["style_deserializers", "StyleDeserializersFactory"]
 
 style_deserializers: StyleDeserializersDict = {
     "matrix": matrix_loads,
@@ -21,7 +21,3 @@ style_deserializers: StyleDeserializersDict = {
     "pipeDelimited": pipe_delimited_loads,
     "deepObject": deep_object_loads,
 }
-
-style_deserializers_factory = StyleDeserializersFactory(
-    style_deserializers=style_deserializers,
-)

--- a/openapi_core/deserializing/styles/factories.py
+++ b/openapi_core/deserializing/styles/factories.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 from jsonschema_path import SchemaPath
 
+from openapi_core.casting.schemas.factories import SchemaCastersFactory
 from openapi_core.deserializing.styles.datatypes import StyleDeserializersDict
 from openapi_core.deserializing.styles.deserializers import StyleDeserializer
 
@@ -9,8 +10,10 @@ from openapi_core.deserializing.styles.deserializers import StyleDeserializer
 class StyleDeserializersFactory:
     def __init__(
         self,
+        schema_casters_factory: SchemaCastersFactory,
         style_deserializers: Optional[StyleDeserializersDict] = None,
     ):
+        self.schema_casters_factory = schema_casters_factory
         if style_deserializers is None:
             style_deserializers = {}
         self.style_deserializers = style_deserializers
@@ -22,9 +25,8 @@ class StyleDeserializersFactory:
         schema: SchemaPath,
         name: str,
     ) -> StyleDeserializer:
-        schema_type = schema.getkey("type", "")
-
         deserialize_callable = self.style_deserializers.get(style)
+        caster = self.schema_casters_factory.create(schema)
         return StyleDeserializer(
-            style, explode, name, schema_type, deserialize_callable
+            style, explode, name, schema, caster, deserialize_callable
         )

--- a/openapi_core/unmarshalling/request/protocols.py
+++ b/openapi_core/unmarshalling/request/protocols.py
@@ -8,16 +8,12 @@ from jsonschema_path import SchemaPath
 from openapi_spec_validator.validation.types import SpecValidatorType
 
 from openapi_core.casting.schemas.factories import SchemaCastersFactory
-from openapi_core.deserializing.media_types import (
-    media_type_deserializers_factory,
-)
 from openapi_core.deserializing.media_types.datatypes import (
     MediaTypeDeserializersDict,
 )
 from openapi_core.deserializing.media_types.factories import (
     MediaTypeDeserializersFactory,
 )
-from openapi_core.deserializing.styles import style_deserializers_factory
 from openapi_core.deserializing.styles.factories import (
     StyleDeserializersFactory,
 )
@@ -43,8 +39,12 @@ class RequestUnmarshaller(Protocol):
         self,
         spec: SchemaPath,
         base_url: Optional[str] = None,
-        style_deserializers_factory: StyleDeserializersFactory = style_deserializers_factory,
-        media_type_deserializers_factory: MediaTypeDeserializersFactory = media_type_deserializers_factory,
+        style_deserializers_factory: Optional[
+            StyleDeserializersFactory
+        ] = None,
+        media_type_deserializers_factory: Optional[
+            MediaTypeDeserializersFactory
+        ] = None,
         schema_casters_factory: Optional[SchemaCastersFactory] = None,
         schema_validators_factory: Optional[SchemaValidatorsFactory] = None,
         path_finder_cls: Optional[PathFinderType] = None,
@@ -74,8 +74,12 @@ class WebhookRequestUnmarshaller(Protocol):
         self,
         spec: SchemaPath,
         base_url: Optional[str] = None,
-        style_deserializers_factory: StyleDeserializersFactory = style_deserializers_factory,
-        media_type_deserializers_factory: MediaTypeDeserializersFactory = media_type_deserializers_factory,
+        style_deserializers_factory: Optional[
+            StyleDeserializersFactory
+        ] = None,
+        media_type_deserializers_factory: Optional[
+            MediaTypeDeserializersFactory
+        ] = None,
         schema_casters_factory: Optional[SchemaCastersFactory] = None,
         schema_validators_factory: Optional[SchemaValidatorsFactory] = None,
         path_finder_cls: Optional[PathFinderType] = None,

--- a/openapi_core/unmarshalling/request/unmarshallers.py
+++ b/openapi_core/unmarshalling/request/unmarshallers.py
@@ -4,16 +4,12 @@ from jsonschema_path import SchemaPath
 from openapi_spec_validator.validation.types import SpecValidatorType
 
 from openapi_core.casting.schemas.factories import SchemaCastersFactory
-from openapi_core.deserializing.media_types import (
-    media_type_deserializers_factory,
-)
 from openapi_core.deserializing.media_types.datatypes import (
     MediaTypeDeserializersDict,
 )
 from openapi_core.deserializing.media_types.factories import (
     MediaTypeDeserializersFactory,
 )
-from openapi_core.deserializing.styles import style_deserializers_factory
 from openapi_core.deserializing.styles.factories import (
     StyleDeserializersFactory,
 )
@@ -85,8 +81,12 @@ class BaseRequestUnmarshaller(BaseRequestValidator, BaseUnmarshaller):
         self,
         spec: SchemaPath,
         base_url: Optional[str] = None,
-        style_deserializers_factory: StyleDeserializersFactory = style_deserializers_factory,
-        media_type_deserializers_factory: MediaTypeDeserializersFactory = media_type_deserializers_factory,
+        style_deserializers_factory: Optional[
+            StyleDeserializersFactory
+        ] = None,
+        media_type_deserializers_factory: Optional[
+            MediaTypeDeserializersFactory
+        ] = None,
         schema_casters_factory: Optional[SchemaCastersFactory] = None,
         schema_validators_factory: Optional[SchemaValidatorsFactory] = None,
         path_finder_cls: Optional[PathFinderType] = None,

--- a/openapi_core/unmarshalling/response/protocols.py
+++ b/openapi_core/unmarshalling/response/protocols.py
@@ -8,16 +8,12 @@ from jsonschema_path import SchemaPath
 from openapi_spec_validator.validation.types import SpecValidatorType
 
 from openapi_core.casting.schemas.factories import SchemaCastersFactory
-from openapi_core.deserializing.media_types import (
-    media_type_deserializers_factory,
-)
 from openapi_core.deserializing.media_types.datatypes import (
     MediaTypeDeserializersDict,
 )
 from openapi_core.deserializing.media_types.factories import (
     MediaTypeDeserializersFactory,
 )
-from openapi_core.deserializing.styles import style_deserializers_factory
 from openapi_core.deserializing.styles.factories import (
     StyleDeserializersFactory,
 )
@@ -44,8 +40,12 @@ class ResponseUnmarshaller(Protocol):
         self,
         spec: SchemaPath,
         base_url: Optional[str] = None,
-        style_deserializers_factory: StyleDeserializersFactory = style_deserializers_factory,
-        media_type_deserializers_factory: MediaTypeDeserializersFactory = media_type_deserializers_factory,
+        style_deserializers_factory: Optional[
+            StyleDeserializersFactory
+        ] = None,
+        media_type_deserializers_factory: Optional[
+            MediaTypeDeserializersFactory
+        ] = None,
         schema_casters_factory: Optional[SchemaCastersFactory] = None,
         schema_validators_factory: Optional[SchemaValidatorsFactory] = None,
         path_finder_cls: Optional[PathFinderType] = None,
@@ -75,8 +75,12 @@ class WebhookResponseUnmarshaller(Protocol):
         self,
         spec: SchemaPath,
         base_url: Optional[str] = None,
-        style_deserializers_factory: StyleDeserializersFactory = style_deserializers_factory,
-        media_type_deserializers_factory: MediaTypeDeserializersFactory = media_type_deserializers_factory,
+        style_deserializers_factory: Optional[
+            StyleDeserializersFactory
+        ] = None,
+        media_type_deserializers_factory: Optional[
+            MediaTypeDeserializersFactory
+        ] = None,
         schema_casters_factory: Optional[SchemaCastersFactory] = None,
         schema_validators_factory: Optional[SchemaValidatorsFactory] = None,
         path_finder_cls: Optional[PathFinderType] = None,

--- a/openapi_core/unmarshalling/unmarshallers.py
+++ b/openapi_core/unmarshalling/unmarshallers.py
@@ -7,16 +7,12 @@ from jsonschema_path import SchemaPath
 from openapi_spec_validator.validation.types import SpecValidatorType
 
 from openapi_core.casting.schemas.factories import SchemaCastersFactory
-from openapi_core.deserializing.media_types import (
-    media_type_deserializers_factory,
-)
 from openapi_core.deserializing.media_types.datatypes import (
     MediaTypeDeserializersDict,
 )
 from openapi_core.deserializing.media_types.factories import (
     MediaTypeDeserializersFactory,
 )
-from openapi_core.deserializing.styles import style_deserializers_factory
 from openapi_core.deserializing.styles.factories import (
     StyleDeserializersFactory,
 )
@@ -39,8 +35,12 @@ class BaseUnmarshaller(BaseValidator):
         self,
         spec: SchemaPath,
         base_url: Optional[str] = None,
-        style_deserializers_factory: StyleDeserializersFactory = style_deserializers_factory,
-        media_type_deserializers_factory: MediaTypeDeserializersFactory = media_type_deserializers_factory,
+        style_deserializers_factory: Optional[
+            StyleDeserializersFactory
+        ] = None,
+        media_type_deserializers_factory: Optional[
+            MediaTypeDeserializersFactory
+        ] = None,
         schema_casters_factory: Optional[SchemaCastersFactory] = None,
         schema_validators_factory: Optional[SchemaValidatorsFactory] = None,
         path_finder_cls: Optional[PathFinderType] = None,

--- a/openapi_core/validation/configurations.py
+++ b/openapi_core/validation/configurations.py
@@ -2,16 +2,12 @@ from dataclasses import dataclass
 from typing import Optional
 
 from openapi_core.casting.schemas.factories import SchemaCastersFactory
-from openapi_core.deserializing.media_types import (
-    media_type_deserializers_factory,
-)
 from openapi_core.deserializing.media_types.datatypes import (
     MediaTypeDeserializersDict,
 )
 from openapi_core.deserializing.media_types.factories import (
     MediaTypeDeserializersFactory,
 )
-from openapi_core.deserializing.styles import style_deserializers_factory
 from openapi_core.deserializing.styles.factories import (
     StyleDeserializersFactory,
 )
@@ -53,12 +49,10 @@ class ValidatorConfig:
     path_finder_cls: Optional[PathFinderType] = None
     webhook_path_finder_cls: Optional[PathFinderType] = None
 
-    style_deserializers_factory: StyleDeserializersFactory = (
-        style_deserializers_factory
-    )
-    media_type_deserializers_factory: MediaTypeDeserializersFactory = (
-        media_type_deserializers_factory
-    )
+    style_deserializers_factory: Optional[StyleDeserializersFactory] = None
+    media_type_deserializers_factory: Optional[
+        MediaTypeDeserializersFactory
+    ] = None
     schema_casters_factory: Optional[SchemaCastersFactory] = None
     schema_validators_factory: Optional[SchemaValidatorsFactory] = None
 

--- a/openapi_core/validation/request/protocols.py
+++ b/openapi_core/validation/request/protocols.py
@@ -9,16 +9,12 @@ from jsonschema_path import SchemaPath
 from openapi_spec_validator.validation.types import SpecValidatorType
 
 from openapi_core.casting.schemas.factories import SchemaCastersFactory
-from openapi_core.deserializing.media_types import (
-    media_type_deserializers_factory,
-)
 from openapi_core.deserializing.media_types.datatypes import (
     MediaTypeDeserializersDict,
 )
 from openapi_core.deserializing.media_types.factories import (
     MediaTypeDeserializersFactory,
 )
-from openapi_core.deserializing.styles import style_deserializers_factory
 from openapi_core.deserializing.styles.factories import (
     StyleDeserializersFactory,
 )
@@ -37,8 +33,12 @@ class RequestValidator(Protocol):
         self,
         spec: SchemaPath,
         base_url: Optional[str] = None,
-        style_deserializers_factory: StyleDeserializersFactory = style_deserializers_factory,
-        media_type_deserializers_factory: MediaTypeDeserializersFactory = media_type_deserializers_factory,
+        style_deserializers_factory: Optional[
+            StyleDeserializersFactory
+        ] = None,
+        media_type_deserializers_factory: Optional[
+            MediaTypeDeserializersFactory
+        ] = None,
         schema_casters_factory: Optional[SchemaCastersFactory] = None,
         schema_validators_factory: Optional[SchemaValidatorsFactory] = None,
         path_finder_cls: Optional[PathFinderType] = None,
@@ -68,8 +68,12 @@ class WebhookRequestValidator(Protocol):
         self,
         spec: SchemaPath,
         base_url: Optional[str] = None,
-        style_deserializers_factory: StyleDeserializersFactory = style_deserializers_factory,
-        media_type_deserializers_factory: MediaTypeDeserializersFactory = media_type_deserializers_factory,
+        style_deserializers_factory: Optional[
+            StyleDeserializersFactory
+        ] = None,
+        media_type_deserializers_factory: Optional[
+            MediaTypeDeserializersFactory
+        ] = None,
         schema_casters_factory: Optional[SchemaCastersFactory] = None,
         schema_validators_factory: Optional[SchemaValidatorsFactory] = None,
         path_finder_cls: Optional[PathFinderType] = None,

--- a/openapi_core/validation/request/validators.py
+++ b/openapi_core/validation/request/validators.py
@@ -16,16 +16,12 @@ from openapi_core.casting.schemas import oas31_schema_casters_factory
 from openapi_core.casting.schemas.factories import SchemaCastersFactory
 from openapi_core.datatypes import Parameters
 from openapi_core.datatypes import RequestParameters
-from openapi_core.deserializing.media_types import (
-    media_type_deserializers_factory,
-)
 from openapi_core.deserializing.media_types.datatypes import (
     MediaTypeDeserializersDict,
 )
 from openapi_core.deserializing.media_types.factories import (
     MediaTypeDeserializersFactory,
 )
-from openapi_core.deserializing.styles import style_deserializers_factory
 from openapi_core.deserializing.styles.factories import (
     StyleDeserializersFactory,
 )
@@ -71,8 +67,12 @@ class BaseRequestValidator(BaseValidator):
         self,
         spec: SchemaPath,
         base_url: Optional[str] = None,
-        style_deserializers_factory: StyleDeserializersFactory = style_deserializers_factory,
-        media_type_deserializers_factory: MediaTypeDeserializersFactory = media_type_deserializers_factory,
+        style_deserializers_factory: Optional[
+            StyleDeserializersFactory
+        ] = None,
+        media_type_deserializers_factory: Optional[
+            MediaTypeDeserializersFactory
+        ] = None,
         schema_casters_factory: Optional[SchemaCastersFactory] = None,
         schema_validators_factory: Optional[SchemaValidatorsFactory] = None,
         path_finder_cls: Optional[PathFinderType] = None,

--- a/openapi_core/validation/response/protocols.py
+++ b/openapi_core/validation/response/protocols.py
@@ -9,16 +9,12 @@ from jsonschema_path import SchemaPath
 from openapi_spec_validator.validation.types import SpecValidatorType
 
 from openapi_core.casting.schemas.factories import SchemaCastersFactory
-from openapi_core.deserializing.media_types import (
-    media_type_deserializers_factory,
-)
 from openapi_core.deserializing.media_types.datatypes import (
     MediaTypeDeserializersDict,
 )
 from openapi_core.deserializing.media_types.factories import (
     MediaTypeDeserializersFactory,
 )
-from openapi_core.deserializing.styles import style_deserializers_factory
 from openapi_core.deserializing.styles.factories import (
     StyleDeserializersFactory,
 )
@@ -36,8 +32,12 @@ class ResponseValidator(Protocol):
         self,
         spec: SchemaPath,
         base_url: Optional[str] = None,
-        style_deserializers_factory: StyleDeserializersFactory = style_deserializers_factory,
-        media_type_deserializers_factory: MediaTypeDeserializersFactory = media_type_deserializers_factory,
+        style_deserializers_factory: Optional[
+            StyleDeserializersFactory
+        ] = None,
+        media_type_deserializers_factory: Optional[
+            MediaTypeDeserializersFactory
+        ] = None,
         schema_casters_factory: Optional[SchemaCastersFactory] = None,
         schema_validators_factory: Optional[SchemaValidatorsFactory] = None,
         path_finder_cls: Optional[PathFinderType] = None,
@@ -68,8 +68,12 @@ class WebhookResponseValidator(Protocol):
         self,
         spec: SchemaPath,
         base_url: Optional[str] = None,
-        style_deserializers_factory: StyleDeserializersFactory = style_deserializers_factory,
-        media_type_deserializers_factory: MediaTypeDeserializersFactory = media_type_deserializers_factory,
+        style_deserializers_factory: Optional[
+            StyleDeserializersFactory
+        ] = None,
+        media_type_deserializers_factory: Optional[
+            MediaTypeDeserializersFactory
+        ] = None,
         schema_casters_factory: Optional[SchemaCastersFactory] = None,
         schema_validators_factory: Optional[SchemaValidatorsFactory] = None,
         path_finder_cls: Optional[PathFinderType] = None,

--- a/tests/integration/test_petstore.py
+++ b/tests/integration/test_petstore.py
@@ -1689,7 +1689,7 @@ class TestPetstore:
                 spec=spec,
                 cls=V30RequestBodyValidator,
             )
-        assert type(exc_info.value.__cause__) is CastError
+        assert type(exc_info.value.__cause__) is InvalidSchemaValue
 
     def test_post_tags_additional_properties(self, spec):
         host_url = "http://petstore.swagger.io/v1"

--- a/tests/integration/validation/test_strict_json_validation.py
+++ b/tests/integration/validation/test_strict_json_validation.py
@@ -1,0 +1,232 @@
+import json
+
+import pytest
+from jsonschema_path import SchemaPath
+
+from openapi_core import V30RequestValidator
+from openapi_core import V30ResponseValidator
+from openapi_core.testing import MockRequest
+from openapi_core.testing import MockResponse
+from openapi_core.validation.request.exceptions import InvalidRequestBody
+from openapi_core.validation.response.exceptions import InvalidData
+
+
+def _spec_schema_path() -> SchemaPath:
+    spec_dict = {
+        "openapi": "3.0.3",
+        "info": {"title": "Strict JSON Validation", "version": "1.0.0"},
+        "servers": [{"url": "http://example.com"}],
+        "paths": {
+            "/users": {
+                "post": {
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/json": {
+                                "schema": {"$ref": "#/components/schemas/User"}
+                            },
+                            "application/problem+json": {
+                                "schema": {"$ref": "#/components/schemas/User"}
+                            },
+                        },
+                    },
+                    "responses": {
+                        "204": {"description": "No content"},
+                    },
+                },
+                "put": {
+                    "requestBody": {
+                        "required": True,
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                },
+                                "encoding": {
+                                    "age": {"contentType": "application/json"},
+                                },
+                            }
+                        },
+                    },
+                    "responses": {
+                        "204": {"description": "No content"},
+                    },
+                },
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "OK",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/User"
+                                    }
+                                },
+                                "application/problem+json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/User"
+                                    }
+                                },
+                            },
+                        }
+                    }
+                },
+            }
+        },
+        "components": {
+            "schemas": {
+                "User": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string", "format": "uuid"},
+                        "username": {"type": "string"},
+                        "age": {"type": "integer"},
+                    },
+                    "required": ["id", "username", "age"],
+                }
+            }
+        },
+    }
+    return SchemaPath.from_dict(spec_dict)
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    [
+        "application/json",
+        "application/problem+json",
+    ],
+)
+def test_response_validator_strict_json_types(content_type: str) -> None:
+    spec = _spec_schema_path()
+    validator = V30ResponseValidator(spec)
+
+    request = MockRequest("http://example.com", "get", "/users")
+    response_json = {
+        "id": "123e4567-e89b-12d3-a456-426614174000",
+        "username": "Test User",
+        "age": "30",
+    }
+    response = MockResponse(
+        json.dumps(response_json).encode("utf-8"),
+        status_code=200,
+        content_type=content_type,
+    )
+
+    with pytest.raises(InvalidData):
+        validator.validate(request, response)
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    [
+        "application/json",
+        "application/problem+json",
+    ],
+)
+def test_request_validator_strict_json_types(content_type: str) -> None:
+    spec = _spec_schema_path()
+    validator = V30RequestValidator(spec)
+
+    request_json = {
+        "id": "123e4567-e89b-12d3-a456-426614174000",
+        "username": "Test User",
+        "age": "30",
+    }
+    request = MockRequest(
+        "http://example.com",
+        "post",
+        "/users",
+        content_type=content_type,
+        data=json.dumps(request_json).encode("utf-8"),
+    )
+
+    with pytest.raises(InvalidRequestBody):
+        validator.validate(request)
+
+
+def test_request_validator_urlencoded_json_part_strict() -> None:
+    spec = _spec_schema_path()
+    validator = V30RequestValidator(spec)
+
+    # urlencoded field age is declared as application/json (via encoding)
+    # and contains a JSON string "30" (invalid for integer schema)
+    request = MockRequest(
+        "http://example.com",
+        "put",
+        "/users",
+        content_type="application/x-www-form-urlencoded",
+        data=(
+            b"id=123e4567-e89b-12d3-a456-426614174000&"
+            b"username=Test+User&"
+            b"age=%2230%22"
+        ),
+    )
+
+    with pytest.raises(InvalidRequestBody):
+        validator.validate(request)
+
+
+def test_response_validator_strict_json_nested_types() -> None:
+    """Test that nested JSON structures (arrays, objects) remain strict."""
+    spec_dict = {
+        "openapi": "3.0.3",
+        "info": {"title": "Nested JSON Test", "version": "1.0.0"},
+        "servers": [{"url": "http://example.com"}],
+        "paths": {
+            "/data": {
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "OK",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "ids": {
+                                                "type": "array",
+                                                "items": {"type": "integer"},
+                                            },
+                                            "metadata": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "count": {
+                                                        "type": "integer"
+                                                    }
+                                                },
+                                            },
+                                        },
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        },
+    }
+    spec = SchemaPath.from_dict(spec_dict)
+    validator = V30ResponseValidator(spec)
+
+    request = MockRequest("http://example.com", "get", "/data")
+
+    # Test nested array with string integers (should fail)
+    response_json = {"ids": ["10", "20", "30"], "metadata": {"count": 5}}
+    response = MockResponse(
+        json.dumps(response_json).encode("utf-8"),
+        status_code=200,
+        content_type="application/json",
+    )
+    with pytest.raises(InvalidData):
+        validator.validate(request, response)
+
+    # Test nested object with string integer (should fail)
+    response_json2 = {"ids": [10, 20, 30], "metadata": {"count": "5"}}
+    response2 = MockResponse(
+        json.dumps(response_json2).encode("utf-8"),
+        status_code=200,
+        content_type="application/json",
+    )
+    with pytest.raises(InvalidData):
+        validator.validate(request, response2)

--- a/tests/unit/deserializing/test_styles_deserializers.py
+++ b/tests/unit/deserializing/test_styles_deserializers.py
@@ -2,14 +2,23 @@ import pytest
 from jsonschema_path import SchemaPath
 from werkzeug.datastructures import ImmutableMultiDict
 
+from openapi_core.casting.schemas import oas31_schema_casters_factory
 from openapi_core.deserializing.exceptions import DeserializeError
-from openapi_core.deserializing.styles import style_deserializers_factory
+from openapi_core.deserializing.styles import style_deserializers
+from openapi_core.deserializing.styles.factories import (
+    StyleDeserializersFactory,
+)
 from openapi_core.schema.parameters import get_style_and_explode
 
 
 class TestParameterStyleDeserializer:
     @pytest.fixture
     def deserializer_factory(self):
+        style_deserializers_factory = StyleDeserializersFactory(
+            oas31_schema_casters_factory,
+            style_deserializers=style_deserializers,
+        )
+
         def create_deserializer(param, name=None):
             name = name or param["name"]
             style, explode = get_style_and_explode(param)


### PR DESCRIPTION
Casting is part of style deserialization.

## Backward incpomatibilities
* `style_deserializers_factory` and `media_tyles_deserialization_factory` defaults to `None` in configuration and protocols
* `CastError` inherits from `DeserializeError`
* `StyleDeserializersFactory` requires `schema_caster_factory`
* removed `style_deserialization_factory` and `media_tyles_deserialization_factory` objects

Relates #1074
Fixes #1017 #800 #819 #706

