### PR TITLE
Validation context

### DIFF
--- a/openapi_core/deserializing/media_types/deserializers.py
+++ b/openapi_core/deserializing/media_types/deserializers.py
@@ -23,6 +23,7 @@ from openapi_core.schema.parameters import get_style_and_explode
 from openapi_core.schema.protocols import SuportsGetAll
 from openapi_core.schema.protocols import SuportsGetList
 from openapi_core.schema.schemas import get_properties
+from openapi_core.validation.schemas.exceptions import ValidateError
 from openapi_core.validation.schemas.validators import SchemaValidator
 
 if TYPE_CHECKING:
@@ -126,6 +127,8 @@ class MediaTypeDeserializer:
             schema=schema,
             schema_validator=schema_validator,
             schema_caster=schema_caster,
+            encoding=self.encoding,
+            **self.parameters,
         )
 
     def decode(
@@ -137,27 +140,21 @@ class MediaTypeDeserializer:
 
         # For urlencoded/multipart, use caster for oneOf/anyOf detection if validator available
         if self.schema_validator is not None:
-            one_of_schema = self.schema_validator.get_one_of_schema(
-                location, caster=self.schema_caster
-            )
+            one_of_schema = self.get_composed_one_of_schema(location)
             if one_of_schema is not None:
                 one_of_properties = self.evolve(one_of_schema).decode(
                     location, schema_only=True
                 )
                 properties.update(one_of_properties)
 
-            any_of_schemas = self.schema_validator.iter_any_of_schemas(
-                location, caster=self.schema_caster
-            )
+            any_of_schemas = self.iter_composed_any_of_schemas(location)
             for any_of_schema in any_of_schemas:
                 any_of_properties = self.evolve(any_of_schema).decode(
                     location, schema_only=True
                 )
                 properties.update(any_of_properties)
 
-            all_of_schemas = self.schema_validator.iter_all_of_schemas(
-                location
-            )
+            all_of_schemas = self.iter_composed_all_of_schemas(location)
             for all_of_schema in all_of_schemas:
                 all_of_properties = self.evolve(all_of_schema).decode(
                     location, schema_only=True
@@ -220,6 +217,13 @@ class MediaTypeDeserializer:
         location: Mapping[str, Any],
         prep_encoding: SchemaPath,
     ) -> Any:
+        if self.mimetype.startswith("multipart"):
+            location = self.normalize_multipart_form_location(
+                prop_name,
+                prop_schema,
+                location,
+            )
+
         prop_style, prop_explode = get_style_and_explode(
             prep_encoding, default_location="query"
         )
@@ -227,6 +231,81 @@ class MediaTypeDeserializer:
             self.spec, prop_schema, prop_style, prop_explode, name=prop_name
         )
         return prop_deserializer.deserialize(location)
+
+    def normalize_multipart_form_location(
+        self,
+        prop_name: str,
+        prop_schema: SchemaPath,
+        location: Mapping[str, Any],
+    ) -> Mapping[str, Any]:
+        if not self.should_decode_multipart_form_value(prop_schema):
+            return location
+
+        if prop_name not in location:
+            return location
+
+        normalized = dict(location)
+        value = location[prop_name]
+
+        if isinstance(value, bytes):
+            normalized[prop_name] = self.decode_multipart_form_value(value)
+            return normalized
+
+        if isinstance(value, list):
+            normalized[prop_name] = [
+                (
+                    self.decode_multipart_form_value(item)
+                    if isinstance(item, bytes)
+                    else item
+                )
+                for item in value
+            ]
+            return normalized
+
+        if isinstance(location, SuportsGetAll):
+            values = location.getall(prop_name)
+            if any(isinstance(item, bytes) for item in values):
+                normalized[prop_name] = [
+                    (
+                        self.decode_multipart_form_value(item)
+                        if isinstance(item, bytes)
+                        else item
+                    )
+                    for item in values
+                ]
+                return normalized
+
+        if isinstance(location, SuportsGetList):
+            values = location.getlist(prop_name)
+            if any(isinstance(item, bytes) for item in values):
+                normalized[prop_name] = [
+                    (
+                        self.decode_multipart_form_value(item)
+                        if isinstance(item, bytes)
+                        else item
+                    )
+                    for item in values
+                ]
+
+        return normalized
+
+    def should_decode_multipart_form_value(
+        self,
+        prop_schema: SchemaPath,
+    ) -> bool:
+        schema_type = (prop_schema / "type").read_str(None)
+        schema_format = (prop_schema / "format").read_str(None)
+
+        if schema_type in ["integer", "number", "boolean"]:
+            return True
+
+        return schema_type == "string" and schema_format != "binary"
+
+    def decode_multipart_form_value(self, value: bytes) -> str:
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.decode("ASCII", errors="surrogateescape")
 
     def decode_property_content_type(
         self,
@@ -253,3 +332,76 @@ class MediaTypeDeserializer:
                 return list(map(prop_deserializer.deserialize, value))
 
         return prop_deserializer.deserialize(location[prop_name])
+
+    def get_composed_one_of_schema(
+        self, location: Mapping[str, Any]
+    ) -> Optional[SchemaPath]:
+        assert self.schema_validator is not None
+
+        if not self.mimetype.startswith("multipart"):
+            return self.schema_validator.get_one_of_schema(
+                location, caster=self.schema_caster
+            )
+
+        if self.schema is None or "oneOf" not in self.schema:
+            return None
+
+        for subschema in self.schema / "oneOf":
+            if self.is_decoded_subschema_valid(subschema, location):
+                return subschema
+
+        return None
+
+    def iter_composed_any_of_schemas(
+        self, location: Mapping[str, Any]
+    ) -> list[SchemaPath]:
+        assert self.schema_validator is not None
+
+        if not self.mimetype.startswith("multipart"):
+            return list(
+                self.schema_validator.iter_any_of_schemas(
+                    location, caster=self.schema_caster
+                )
+            )
+
+        if self.schema is None or "anyOf" not in self.schema:
+            return []
+
+        return [
+            subschema
+            for subschema in self.schema / "anyOf"
+            if self.is_decoded_subschema_valid(subschema, location)
+        ]
+
+    def iter_composed_all_of_schemas(
+        self, location: Mapping[str, Any]
+    ) -> list[SchemaPath]:
+        assert self.schema_validator is not None
+
+        if not self.mimetype.startswith("multipart"):
+            return list(self.schema_validator.iter_all_of_schemas(location))
+
+        if self.schema is None or "allOf" not in self.schema:
+            return []
+
+        return [
+            subschema
+            for subschema in self.schema / "allOf"
+            if self.is_decoded_subschema_valid(subschema, location)
+        ]
+
+    def is_decoded_subschema_valid(
+        self,
+        subschema: SchemaPath,
+        location: Mapping[str, Any],
+    ) -> bool:
+        assert self.schema_validator is not None
+
+        deserializer = self.evolve(subschema)
+        candidate = deserializer.decode(location)
+        validator = self.schema_validator.evolve(subschema)
+        try:
+            validator.validate(candidate)
+        except ValidateError:
+            return False
+        return True

--- a/openapi_core/unmarshalling/schemas/unmarshallers.py
+++ b/openapi_core/unmarshalling/schemas/unmarshallers.py
@@ -46,7 +46,18 @@ class ArrayUnmarshaller(PrimitiveUnmarshaller):
                 self.items_unmarshaller.unmarshal_state(item_state)
                 for item_state in state.item_states
             ]
-        return self(value=state.value)
+        # No per-item states means the item schema didn't need state
+        # (predicate said so). The outer validate() has already covered
+        # each item, so go through unmarshal_state with a bare state
+        # rather than unmarshal (which would re-validate).
+        items_unmarshaller = self.items_unmarshaller
+        items_schema = items_unmarshaller.schema
+        return [
+            items_unmarshaller.unmarshal_state(
+                ValidationState(schema=items_schema, value=item)
+            )
+            for item in state.value
+        ]
 
     @property
     def items_unmarshaller(self) -> "SchemaUnmarshaller":
@@ -196,10 +207,20 @@ class ObjectUnmarshaller(PrimitiveUnmarshaller):
             except KeyError:
                 if "default" not in prop_schema:
                     continue
+                # Default values were not part of the validated input,
+                # so they must go through full unmarshal (revalidates).
                 prop_value = (prop_schema / "default").read_value()
+                properties[prop_name] = self.schema_unmarshaller.evolve(
+                    prop_schema
+                ).unmarshal(prop_value)
+                continue
+            # Present-but-state-skipped: validate() already covered it,
+            # so a bare-state unmarshal_state avoids re-validation.
             properties[prop_name] = self.schema_unmarshaller.evolve(
                 prop_schema
-            ).unmarshal(prop_value)
+            ).unmarshal_state(
+                ValidationState(schema=prop_schema, value=prop_value)
+            )
 
         if schema_only:
             return properties
@@ -226,8 +247,13 @@ class ObjectUnmarshaller(PrimitiveUnmarshaller):
                         )
                     )
                     continue
-                properties[prop_name] = additional_prop_unmarshaler.unmarshal(
-                    prop_value
+                # State skipped for trivial child; validate() covered it.
+                properties[prop_name] = (
+                    additional_prop_unmarshaler.unmarshal_state(
+                        ValidationState(
+                            schema=additional_prop_schema, value=prop_value
+                        )
+                    )
                 )
 
         return properties
@@ -246,8 +272,34 @@ class MultiTypeUnmarshaller(PrimitiveUnmarshaller):
 
     def unmarshal_state(self, state: ValidationState) -> Any:
         primitive_type = state.primitive_type
+        # Bare-state fast paths (used for sub-trees that didn't need
+        # full state-building) carry primitive_type=None. Fall back to
+        # computing it from the value -- it's the same work
+        # MultiTypeUnmarshaller.__call__ does, only when actually
+        # needed, and only for sub-trees too trivial to cache.
         if primitive_type is None:
-            return None
+            primitive_type = self.schema_validator.get_primitive_type(
+                state.value
+            )
+            if primitive_type is None:
+                return None
+        # If the matched validation result lives in a composed branch
+        # (oneOf / first anyOf), the type unmarshaller must be bound
+        # to THAT branch's schema -- not to ours -- so nested keywords
+        # like `items` / `properties` resolve against the matched
+        # branch. Without this, an outer "pure-oneOf" schema would
+        # dispatch to an ArrayUnmarshaller bound to a schema with no
+        # `items` keyword. Walk the chain to its leaf.
+        target_state = state
+        while target_state.one_of_state is not None:
+            target_state = target_state.one_of_state
+        if target_state is state and state.any_of_states:
+            target_state = state.any_of_states[0]
+        if target_state is not state:
+            target_unmarshaller = self.schema_unmarshaller.evolve(
+                target_state.schema
+            )
+            return target_unmarshaller.unmarshal_state(target_state)
         unmarshaller = self.schema_unmarshaller.get_type_unmarshaller(
             primitive_type
         )

--- a/openapi_core/unmarshalling/schemas/unmarshallers.py
+++ b/openapi_core/unmarshalling/schemas/unmarshallers.py
@@ -15,6 +15,7 @@ from openapi_core.unmarshalling.schemas.datatypes import FormatUnmarshaller
 from openapi_core.unmarshalling.schemas.datatypes import (
     FormatUnmarshallersDict,
 )
+from openapi_core.validation.schemas.datatypes import ValidationState
 from openapi_core.validation.schemas.validators import SchemaValidator
 
 log = logging.getLogger(__name__)
@@ -39,6 +40,14 @@ class ArrayUnmarshaller(PrimitiveUnmarshaller):
     def __call__(self, value: Any) -> Optional[List[Any]]:
         return list(map(self.items_unmarshaller.unmarshal, value))
 
+    def unmarshal_state(self, state: ValidationState) -> Optional[List[Any]]:
+        if state.item_states:
+            return [
+                self.items_unmarshaller.unmarshal_state(item_state)
+                for item_state in state.item_states
+            ]
+        return self(value=state.value)
+
     @property
     def items_unmarshaller(self) -> "SchemaUnmarshaller":
         # sometimes we don't have any schema i.e. free-form objects
@@ -49,6 +58,14 @@ class ArrayUnmarshaller(PrimitiveUnmarshaller):
 class ObjectUnmarshaller(PrimitiveUnmarshaller):
     def __call__(self, value: Any) -> Any:
         properties = self._unmarshal_properties(value)
+
+        fields: Iterable[str] = properties and properties.keys() or []
+        object_class = self.object_class_factory.create(self.schema, fields)
+
+        return object_class(**properties)
+
+    def unmarshal_state(self, state: ValidationState) -> Any:
+        properties = self._unmarshal_properties_from_state(state)
 
         fields: Iterable[str] = properties and properties.keys() or []
         object_class = self.object_class_factory.create(self.schema, fields)
@@ -131,6 +148,90 @@ class ObjectUnmarshaller(PrimitiveUnmarshaller):
 
         return properties
 
+    def _unmarshal_properties_from_state(
+        self,
+        state: ValidationState,
+        schema_only: bool = False,
+    ) -> Any:
+        value = state.value
+        properties = {}
+
+        if state.one_of_state is not None:
+            one_of_properties = self.evolve(
+                state.one_of_state.schema
+            )._unmarshal_properties_from_state(
+                state.one_of_state,
+                schema_only=True,
+            )
+            properties.update(one_of_properties)
+
+        for any_of_state in state.any_of_states:
+            any_of_properties = self.evolve(
+                any_of_state.schema
+            )._unmarshal_properties_from_state(
+                any_of_state,
+                schema_only=True,
+            )
+            properties.update(any_of_properties)
+
+        for all_of_state in state.all_of_states:
+            all_of_properties = self.evolve(
+                all_of_state.schema
+            )._unmarshal_properties_from_state(
+                all_of_state,
+                schema_only=True,
+            )
+            properties.update(all_of_properties)
+
+        for prop_name, prop_schema in get_properties(self.schema).items():
+            child_state = state.property_states.get(prop_name)
+            if child_state is not None:
+                properties[prop_name] = self.schema_unmarshaller.evolve(
+                    prop_schema
+                ).unmarshal_state(child_state)
+                continue
+
+            try:
+                prop_value = value[prop_name]
+            except KeyError:
+                if "default" not in prop_schema:
+                    continue
+                prop_value = (prop_schema / "default").read_value()
+            properties[prop_name] = self.schema_unmarshaller.evolve(
+                prop_schema
+            ).unmarshal(prop_value)
+
+        if schema_only:
+            return properties
+
+        additional_properties = self.schema.get("additionalProperties", True)
+        if additional_properties is not False:
+            if additional_properties is True:
+                additional_prop_schema = SchemaPath.from_dict(
+                    {"nullable": True}
+                )
+            else:
+                additional_prop_schema = self.schema / "additionalProperties"
+            additional_prop_unmarshaler = self.schema_unmarshaller.evolve(
+                additional_prop_schema
+            )
+            for prop_name, prop_value in value.items():
+                if prop_name in properties:
+                    continue
+                child_state = state.additional_property_states.get(prop_name)
+                if child_state is not None:
+                    properties[prop_name] = (
+                        additional_prop_unmarshaler.unmarshal_state(
+                            child_state
+                        )
+                    )
+                    continue
+                properties[prop_name] = additional_prop_unmarshaler.unmarshal(
+                    prop_value
+                )
+
+        return properties
+
 
 class MultiTypeUnmarshaller(PrimitiveUnmarshaller):
     def __call__(self, value: Any) -> Any:
@@ -142,6 +243,17 @@ class MultiTypeUnmarshaller(PrimitiveUnmarshaller):
             primitive_type
         )
         return unmarshaller(value)
+
+    def unmarshal_state(self, state: ValidationState) -> Any:
+        primitive_type = state.primitive_type
+        if primitive_type is None:
+            return None
+        unmarshaller = self.schema_unmarshaller.get_type_unmarshaller(
+            primitive_type
+        )
+        if hasattr(unmarshaller, "unmarshal_state"):
+            return unmarshaller.unmarshal_state(state)
+        return unmarshaller(state.value)
 
 
 class AnyUnmarshaller(MultiTypeUnmarshaller):
@@ -239,7 +351,11 @@ class SchemaUnmarshaller:
         self.formats_unmarshaller = formats_unmarshaller
 
     def unmarshal(self, value: Any) -> Any:
-        self.schema_validator.validate(value)
+        state = self.schema_validator.validate_state(value)
+        return self.unmarshal_state(state)
+
+    def unmarshal_state(self, state: ValidationState) -> Any:
+        value = state.value
 
         # skip unmarshalling for nullable in OpenAPI 3.0
         if value is None and (self.schema / "nullable").read_bool(
@@ -249,11 +365,14 @@ class SchemaUnmarshaller:
 
         schema_type = (self.schema / "type").read_str_or_list(None)
         type_unmarshaller = self.get_type_unmarshaller(schema_type)
-        typed = type_unmarshaller(value)
+        if hasattr(type_unmarshaller, "unmarshal_state"):
+            typed = type_unmarshaller.unmarshal_state(state)
+        else:
+            typed = type_unmarshaller(value)
         # skip finding format for None
         if typed is None:
             return None
-        schema_format = self.find_format(value)
+        schema_format = self.find_format(value, state=state)
         if schema_format is None:
             return typed
         # ignore incompatible formats
@@ -300,7 +419,21 @@ class SchemaUnmarshaller:
             self.formats_unmarshaller,
         )
 
-    def find_format(self, value: Any) -> Optional[str]:
+    def find_format(
+        self,
+        value: Any,
+        state: Optional[ValidationState] = None,
+    ) -> Optional[str]:
+        if state is not None:
+            for schema in self.iter_valid_schemas_from_state(state):
+                schema_validator = self.schema_validator.evolve(schema)
+                primitive_type = schema_validator.get_primitive_type(value)
+                if primitive_type != "string":
+                    continue
+                if "format" in schema:
+                    return (schema / "format").read_str()
+            return None
+
         for schema in self.schema_validator.iter_valid_schemas(value):
             schema_validator = self.schema_validator.evolve(schema)
             primitive_type = schema_validator.get_primitive_type(value)
@@ -309,3 +442,18 @@ class SchemaUnmarshaller:
             if "format" in schema:
                 return (schema / "format").read_str()
         return None
+
+    def iter_valid_schemas_from_state(
+        self,
+        state: ValidationState,
+    ) -> Iterable[SchemaPath]:
+        yield state.schema
+
+        if state.one_of_state is not None:
+            yield state.one_of_state.schema
+
+        for any_of_state in state.any_of_states:
+            yield any_of_state.schema
+
+        for all_of_state in state.all_of_states:
+            yield all_of_state.schema

--- a/openapi_core/unmarshalling/unmarshallers.py
+++ b/openapi_core/unmarshalling/unmarshallers.py
@@ -101,25 +101,41 @@ class BaseUnmarshaller(BaseValidator):
         )
         return unmarshaller.unmarshal(value)
 
+    def _unmarshal_validated_schema(
+        self, schema: SchemaPath, value: Any
+    ) -> Any:
+        unmarshaller = self.schema_unmarshallers_factory.create(
+            self.spec,
+            schema,
+            format_validators=self.format_validators,
+            extra_format_validators=self.extra_format_validators,
+            forbid_unspecified_additional_properties=self.forbid_unspecified_additional_properties,
+            enforce_properties_required=self.enforce_properties_required,
+            format_unmarshallers=self.format_unmarshallers,
+            extra_format_unmarshallers=self.extra_format_unmarshallers,
+        )
+        state = unmarshaller.schema_validator.validate_state(value)
+        return unmarshaller.unmarshal_state(state)
+
     def _get_param_or_header_and_schema(
         self,
         param_or_header: SchemaPath,
         location: Mapping[str, Any],
         name: Optional[str] = None,
     ) -> Tuple[Any, Optional[SchemaPath]]:
-        casted, schema = super()._get_param_or_header_and_schema(
+        casted, schema = self._get_param_or_header_value_and_schema(
             param_or_header, location, name=name
         )
         if schema is None:
             return casted, None
-        return self._unmarshal_schema(schema, casted), schema
+        return self._unmarshal_validated_schema(schema, casted), schema
 
     def _get_content_and_schema(
         self, raw: Any, content: SchemaPath, mimetype: Optional[str] = None
     ) -> Tuple[Any, Optional[SchemaPath]]:
-        casted, schema = super()._get_content_and_schema(
+        casted, schema = self._get_content_schema_value_and_schema(
             raw, content, mimetype
         )
         if schema is None:
             return casted, None
-        return self._unmarshal_schema(schema, casted), schema
+        return self._unmarshal_validated_schema(schema, casted), schema

--- a/openapi_core/validation/schemas/datatypes.py
+++ b/openapi_core/validation/schemas/datatypes.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
 from dataclasses import field
+from types import MappingProxyType
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import Mapping
 from typing import Optional
-from typing import Tuple
 
 from jsonschema_path import SchemaPath
 
@@ -13,19 +14,49 @@ FormatValidator = Callable[[Any], bool]
 FormatValidatorsDict = Dict[str, FormatValidator]
 
 
-@dataclass(frozen=True)
+# Shared, read-only "empty container" singletons used as the default
+# values for ValidationState collection fields. Because ValidationState
+# is frozen these are safe to share across instances -- there is no
+# code path that mutates the fields after construction. Using a single
+# empty mapping/tuple instead of allocating a fresh dict/() for every
+# leaf state cuts the per-instance allocation count from ~5 to 1.
+_EMPTY_STATES: Mapping[str, "ValidationState"] = MappingProxyType({})
+_EMPTY_STATE_TUPLE: tuple["ValidationState", ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
 class ValidationState:
+    """The result of validating ``value`` against ``schema``.
+
+    Carries forward two pieces of information that the unmarshaller
+    would otherwise have to recompute:
+
+    1. The fact that ``value`` was validated -- so child unmarshallers
+       can skip re-running ``validate()`` against the same value.
+    2. Which composed schemas matched (``one_of_state``,
+       ``any_of_states``, ``all_of_states``) -- so the unmarshaller
+       doesn't have to re-resolve ``oneOf`` / ``anyOf`` / ``allOf``
+       branch selection at unmarshal time.
+
+    State is only built for sub-trees that actually carry one of these
+    two pieces of information. Sub-trees with no composition anywhere
+    don't get a populated state; the unmarshaller takes a fast bare-
+    state path for them. See ``SchemaValidator._schema_needs_state``.
+    """
+
     schema: SchemaPath
     value: Any
     primitive_type: Optional[str] = None
-    property_states: Dict[str, "ValidationState"] = field(default_factory=dict)
-    additional_property_states: Dict[str, "ValidationState"] = field(
-        default_factory=dict
+    property_states: Mapping[str, "ValidationState"] = field(
+        default_factory=lambda: _EMPTY_STATES,
     )
-    item_states: Tuple["ValidationState", ...] = ()
+    additional_property_states: Mapping[str, "ValidationState"] = field(
+        default_factory=lambda: _EMPTY_STATES,
+    )
+    item_states: tuple["ValidationState", ...] = _EMPTY_STATE_TUPLE
     one_of_state: Optional["ValidationState"] = None
-    any_of_states: Tuple["ValidationState", ...] = ()
-    all_of_states: Tuple["ValidationState", ...] = ()
+    any_of_states: tuple["ValidationState", ...] = _EMPTY_STATE_TUPLE
+    all_of_states: tuple["ValidationState", ...] = _EMPTY_STATE_TUPLE
 
 
 __all__ = ["FormatValidator", "FormatValidatorsDict", "ValidationState"]

--- a/openapi_core/validation/schemas/datatypes.py
+++ b/openapi_core/validation/schemas/datatypes.py
@@ -1,7 +1,31 @@
+from dataclasses import dataclass
+from dataclasses import field
 from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import Optional
+from typing import Tuple
+
+from jsonschema_path import SchemaPath
 
 FormatValidator = Callable[[Any], bool]
 
 FormatValidatorsDict = Dict[str, FormatValidator]
+
+
+@dataclass(frozen=True)
+class ValidationState:
+    schema: SchemaPath
+    value: Any
+    primitive_type: Optional[str] = None
+    property_states: Dict[str, "ValidationState"] = field(default_factory=dict)
+    additional_property_states: Dict[str, "ValidationState"] = field(
+        default_factory=dict
+    )
+    item_states: Tuple["ValidationState", ...] = ()
+    one_of_state: Optional["ValidationState"] = None
+    any_of_states: Tuple["ValidationState", ...] = ()
+    all_of_states: Tuple["ValidationState", ...] = ()
+
+
+__all__ = ["FormatValidator", "FormatValidatorsDict", "ValidationState"]

--- a/openapi_core/validation/schemas/validators.py
+++ b/openapi_core/validation/schemas/validators.py
@@ -4,12 +4,19 @@ from functools import partial
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterator
+from typing import Mapping
 from typing import Optional
 
 from jsonschema.exceptions import FormatError
 from jsonschema.protocols import Validator
 from jsonschema_path import SchemaPath
 
+from openapi_core.validation.schemas.datatypes import (
+    _EMPTY_STATE_TUPLE as _EMPTY_STATES_TUPLE,
+)
+from openapi_core.validation.schemas.datatypes import (
+    _EMPTY_STATES as _EMPTY_STATES_MAP,
+)
 from openapi_core.validation.schemas.datatypes import FormatValidator
 from openapi_core.validation.schemas.datatypes import ValidationState
 from openapi_core.validation.schemas.exceptions import InvalidSchemaValue
@@ -40,19 +47,88 @@ class SchemaValidator:
             schema_type = (self.schema / "type").read_str_or_list("any")
             raise InvalidSchemaValue(value, schema_type, schema_errors=errors)
 
+    # Cache the recursive "does this schema benefit from a ValidationState?"
+    # check, keyed on the SchemaPath. SchemaPath is hashed by content, so
+    # two SchemaPaths pointing at the same spec location share a cache
+    # slot regardless of identity -- safe across GC, bounded by the number
+    # of distinct schema shapes in the spec rather than by input volume.
+    _needs_state_cache: dict[SchemaPath, bool] = {}
+
+    @classmethod
+    def _schema_needs_state(cls, schema: SchemaPath) -> bool:
+        """True if building a ValidationState for ``schema`` carries
+        information the unmarshaller can reuse: either composition
+        (oneOf/anyOf/allOf) on this node, or a descendant that does.
+
+        Cycle-safe: a False sentinel is stored before recursing, so a
+        $ref loop terminates and the real answer overwrites the
+        sentinel once the recursion completes.
+        """
+        cache = cls._needs_state_cache
+        cached = cache.get(schema)
+        if cached is not None:
+            return cached
+        # Self-composition is the strongest signal; check it first to
+        # short-circuit the cheap case.
+        if "oneOf" in schema or "anyOf" in schema or "allOf" in schema:
+            cache[schema] = True
+            return True
+        # Seed the in-progress sentinel for cycle protection.
+        cache[schema] = False
+        # Recurse into children. We only need to find one descendant
+        # that needs state to flip our own answer.
+        result = False
+        if "properties" in schema:
+            prop_iter = (schema / "properties").items()
+            for prop_name, prop_schema in prop_iter:
+                if not isinstance(prop_name, str):
+                    continue
+                if cls._schema_needs_state(prop_schema):
+                    result = True
+                    break
+        if not result and "additionalProperties" in schema:
+            try:
+                ap = schema / "additionalProperties"
+            except Exception:
+                ap = None
+            if ap is not None and cls._schema_needs_state(ap):
+                result = True
+        if not result and "items" in schema:
+            try:
+                items = schema / "items"
+            except Exception:
+                items = None
+            if items is not None and cls._schema_needs_state(items):
+                result = True
+        cache[schema] = result
+        return result
+
     def validate_state(self, value: Any) -> ValidationState:
         self.validate(value)
         return self._build_trusted_state(value)
 
     def _build_trusted_state(self, value: Any) -> ValidationState:
-        primitive_type = self.get_primitive_type(value)
-        property_states = {}
-        additional_property_states = {}
-        item_states: tuple[ValidationState, ...] = ()
-        one_of_state = None
-        any_of_states: tuple[ValidationState, ...] = ()
-        all_of_states: tuple[ValidationState, ...] = ()
+        """Build a ValidationState for ``value`` against ``self.schema``.
 
+        Pre-condition: ``value`` has already been validated against the
+        schema (typically by an outer ``validate_state``). This method
+        does NOT re-validate -- it only records the composition-branch
+        decisions and recurses into children that themselves need
+        state.
+        """
+        primitive_type = self.get_primitive_type(value)
+        property_states: Mapping[str, ValidationState] = _EMPTY_STATES_MAP
+        additional_property_states: Mapping[str, ValidationState] = (
+            _EMPTY_STATES_MAP
+        )
+        item_states: tuple[ValidationState, ...] = _EMPTY_STATES_TUPLE
+        one_of_state: Optional[ValidationState] = None
+        any_of_states: tuple[ValidationState, ...] = _EMPTY_STATES_TUPLE
+        all_of_states: tuple[ValidationState, ...] = _EMPTY_STATES_TUPLE
+
+        # Composition keywords: always cache the branch selection,
+        # because re-resolving it at unmarshal time is exactly the work
+        # ValidationState exists to avoid.
         if "oneOf" in self.schema:
             one_of_schema = self.get_one_of_schema(value)
             if one_of_schema is not None:
@@ -76,22 +152,41 @@ class SchemaValidator:
                     for all_of_schema in all_of_schemas
                 )
 
+        # Children: recurse only into sub-trees that themselves contain
+        # composition. Sub-trees without composition can be unmarshalled
+        # via the bare-state fast path -- no cached state needed.
         if primitive_type == "object" and isinstance(value, dict):
+            new_props: dict[str, ValidationState] = {}
             for prop_name, prop_schema in self._get_input_properties(
                 value
             ).items():
-                property_states[prop_name] = self.evolve(
+                if not self._schema_needs_state(prop_schema):
+                    continue
+                new_props[prop_name] = self.evolve(
                     prop_schema
                 )._build_trusted_state(value[prop_name])
+            if new_props:
+                property_states = new_props
+
+            new_addl: dict[str, ValidationState] = {}
             for (
                 prop_name,
                 additional_prop_schema,
             ) in self._get_input_additional_properties(value).items():
-                additional_property_states[prop_name] = self.evolve(
+                if not self._schema_needs_state(additional_prop_schema):
+                    continue
+                new_addl[prop_name] = self.evolve(
                     additional_prop_schema
                 )._build_trusted_state(value[prop_name])
+            if new_addl:
+                additional_property_states = new_addl
         elif primitive_type == "array" and isinstance(value, list):
-            item_states = tuple(self.iter_item_states(value))
+            # Skip per-item state when the item schema itself doesn't
+            # need state -- the unmarshaller's bare-state fast path
+            # handles each item.
+            built = self._build_item_states_if_needed(value)
+            if built:
+                item_states = built
 
         return ValidationState(
             self.schema,
@@ -103,6 +198,19 @@ class SchemaValidator:
             one_of_state=one_of_state,
             any_of_states=any_of_states,
             all_of_states=all_of_states,
+        )
+
+    def _build_item_states_if_needed(
+        self, value: list[Any]
+    ) -> tuple[ValidationState, ...]:
+        if "items" not in self.schema:
+            return _EMPTY_STATES_TUPLE
+        items_schema = self.schema / "items"
+        if not self._schema_needs_state(items_schema):
+            return _EMPTY_STATES_TUPLE
+        item_validator = self.evolve(items_schema)
+        return tuple(
+            item_validator._build_trusted_state(item) for item in value
         )
 
     def evolve(self, schema: SchemaPath) -> "SchemaValidator":

--- a/openapi_core/validation/schemas/validators.py
+++ b/openapi_core/validation/schemas/validators.py
@@ -11,6 +11,7 @@ from jsonschema.protocols import Validator
 from jsonschema_path import SchemaPath
 
 from openapi_core.validation.schemas.datatypes import FormatValidator
+from openapi_core.validation.schemas.datatypes import ValidationState
 from openapi_core.validation.schemas.exceptions import InvalidSchemaValue
 from openapi_core.validation.schemas.exceptions import ValidateError
 
@@ -38,6 +39,71 @@ class SchemaValidator:
         if errors:
             schema_type = (self.schema / "type").read_str_or_list("any")
             raise InvalidSchemaValue(value, schema_type, schema_errors=errors)
+
+    def validate_state(self, value: Any) -> ValidationState:
+        self.validate(value)
+        return self._build_trusted_state(value)
+
+    def _build_trusted_state(self, value: Any) -> ValidationState:
+        primitive_type = self.get_primitive_type(value)
+        property_states = {}
+        additional_property_states = {}
+        item_states: tuple[ValidationState, ...] = ()
+        one_of_state = None
+        any_of_states: tuple[ValidationState, ...] = ()
+        all_of_states: tuple[ValidationState, ...] = ()
+
+        if "oneOf" in self.schema:
+            one_of_schema = self.get_one_of_schema(value)
+            if one_of_schema is not None:
+                one_of_state = self.evolve(one_of_schema)._build_trusted_state(
+                    value
+                )
+
+        if "anyOf" in self.schema:
+            any_of_schemas = tuple(self.iter_any_of_schemas(value))
+            if any_of_schemas:
+                any_of_states = tuple(
+                    self.evolve(any_of_schema)._build_trusted_state(value)
+                    for any_of_schema in any_of_schemas
+                )
+
+        if "allOf" in self.schema:
+            all_of_schemas = tuple(self.iter_all_of_schemas(value))
+            if all_of_schemas:
+                all_of_states = tuple(
+                    self.evolve(all_of_schema)._build_trusted_state(value)
+                    for all_of_schema in all_of_schemas
+                )
+
+        if primitive_type == "object" and isinstance(value, dict):
+            for prop_name, prop_schema in self._get_input_properties(
+                value
+            ).items():
+                property_states[prop_name] = self.evolve(
+                    prop_schema
+                )._build_trusted_state(value[prop_name])
+            for (
+                prop_name,
+                additional_prop_schema,
+            ) in self._get_input_additional_properties(value).items():
+                additional_property_states[prop_name] = self.evolve(
+                    additional_prop_schema
+                )._build_trusted_state(value[prop_name])
+        elif primitive_type == "array" and isinstance(value, list):
+            item_states = tuple(self.iter_item_states(value))
+
+        return ValidationState(
+            self.schema,
+            value,
+            primitive_type=primitive_type,
+            property_states=property_states,
+            additional_property_states=additional_property_states,
+            item_states=item_states,
+            one_of_state=one_of_state,
+            any_of_states=any_of_states,
+            all_of_states=all_of_states,
+        )
 
     def evolve(self, schema: SchemaPath) -> "SchemaValidator":
         cls = self.__class__
@@ -103,6 +169,54 @@ class SchemaValidator:
             return schema_type
         # OpenAPI 3.0: None is not a primitive type so None value will not find any type
         return None
+
+    def iter_item_states(self, value: list[Any]) -> Iterator[ValidationState]:
+        if "items" not in self.schema:
+            any_schema = SchemaPath.from_dict({})
+            any_validator = self.evolve(any_schema)
+            for item in value:
+                yield any_validator._build_trusted_state(item)
+            return
+
+        items_schema = self.schema / "items"
+        item_validator = self.evolve(items_schema)
+        for item in value:
+            yield item_validator._build_trusted_state(item)
+
+    def _get_input_properties(
+        self, value: dict[str, Any]
+    ) -> dict[str, SchemaPath]:
+        if "properties" not in self.schema:
+            return {}
+
+        properties: dict[str, SchemaPath] = {}
+        for prop_name, prop_schema in (self.schema / "properties").items():
+            if not isinstance(prop_name, str):
+                continue
+            if prop_name not in value:
+                continue
+            properties[prop_name] = prop_schema
+
+        return properties
+
+    def _get_input_additional_properties(
+        self, value: dict[str, Any]
+    ) -> dict[str, SchemaPath]:
+        additional_properties = self.schema.get("additionalProperties", True)
+        if additional_properties is False:
+            return {}
+
+        property_names = set(self._get_input_properties(value))
+        if additional_properties is True:
+            additional_prop_schema = SchemaPath.from_dict({"nullable": True})
+        else:
+            additional_prop_schema = self.schema / "additionalProperties"
+
+        return {
+            prop_name: additional_prop_schema
+            for prop_name in value
+            if prop_name not in property_names
+        }
 
     def iter_valid_schemas(self, value: Any) -> Iterator[SchemaPath]:
         yield self.schema

--- a/openapi_core/validation/validators.py
+++ b/openapi_core/validation/validators.py
@@ -192,6 +192,21 @@ class BaseValidator:
         location: Mapping[str, Any],
         name: Optional[str] = None,
     ) -> Tuple[Any, Optional[SchemaPath]]:
+        casted, schema = self._get_param_or_header_value_and_schema(
+            param_or_header, location, name=name
+        )
+
+        if schema is None:
+            return casted, None
+        self._validate_schema(schema, casted)
+        return casted, schema
+
+    def _get_param_or_header_value_and_schema(
+        self,
+        param_or_header: SchemaPath,
+        location: Mapping[str, Any],
+        name: Optional[str] = None,
+    ) -> Tuple[Any, Optional[SchemaPath]]:
         schema: Optional[SchemaPath] = None
         # Simple scenario
         if "content" not in param_or_header:
@@ -203,10 +218,6 @@ class BaseValidator:
             casted, schema = self._get_complex_param_or_header(
                 param_or_header, location, name=name
             )
-
-        if schema is None:
-            return casted, None
-        self._validate_schema(schema, casted)
         return casted, schema
 
     def _get_simple_param_or_header(

--- a/tests/integration/unmarshalling/test_request_unmarshaller.py
+++ b/tests/integration/unmarshalling/test_request_unmarshaller.py
@@ -544,3 +544,78 @@ class TestRequestUnmarshaller:
 
         assert result.errors == []
         assert result.body == {"file": b"\xff\xfe"}
+
+    def test_post_pets_validates_request_schema_once(
+        self, request_unmarshaller
+    ):
+        pet_name = "Cat"
+        pet_tag = "cats"
+        pet_street = "Piekna"
+        pet_city = "Warsaw"
+        data_json = {
+            "name": pet_name,
+            "tag": pet_tag,
+            "position": 2,
+            "address": {
+                "street": pet_street,
+                "city": pet_city,
+            },
+            "ears": {
+                "healthy": True,
+            },
+        }
+        data = json.dumps(data_json).encode()
+        headers = {
+            "api-key": self.api_key_encoded,
+        }
+        cookies = {
+            "user": "123",
+        }
+        request = MockRequest(
+            "https://development.gigantic-server.com",
+            "post",
+            "/v1/pets",
+            path_pattern="/v1/pets",
+            data=data,
+            headers=headers,
+            cookies=cookies,
+        )
+
+        calls = []
+        monkeypatch = pytest.MonkeyPatch()
+        original_create = (
+            request_unmarshaller.schema_unmarshallers_factory.create
+        )
+
+        def spy_create(*args, **kwargs):
+            schema_unmarshaller = original_create(*args, **kwargs)
+            original_method = (
+                schema_unmarshaller.schema_validator.validate_state
+            )
+
+            def spy_validate_state(value):
+                calls.append(schema_unmarshaller.schema)
+                return original_method(value)
+
+            monkeypatch.setattr(
+                schema_unmarshaller.schema_validator,
+                "validate_state",
+                spy_validate_state,
+            )
+            return schema_unmarshaller
+
+        monkeypatch.setattr(
+            request_unmarshaller.schema_unmarshallers_factory,
+            "create",
+            spy_create,
+        )
+        try:
+            result = request_unmarshaller.unmarshal(request)
+        finally:
+            monkeypatch.undo()
+
+        assert result.errors == []
+        body_calls = [
+            schema for schema in calls if "requestBody#content" in str(schema)
+        ]
+        assert len(body_calls) == 1

--- a/tests/integration/unmarshalling/test_response_unmarshaller.py
+++ b/tests/integration/unmarshalling/test_response_unmarshaller.py
@@ -227,3 +227,57 @@ class TestResponseUnmarshaller:
         assert result.data.data[0].id == 1
         assert result.data.data[0].name == "Sparky"
         assert result.headers == {}
+
+    def test_get_pets_validates_response_schema_once(
+        self, response_unmarshaller
+    ):
+        request = MockRequest(self.host_url, "get", "/v1/pets")
+        response_json = {
+            "data": [
+                {
+                    "id": 1,
+                    "name": "Sparky",
+                    "ears": {
+                        "healthy": True,
+                    },
+                },
+            ],
+        }
+        response_data = json.dumps(response_json).encode()
+        response = MockResponse(response_data)
+
+        calls = []
+        monkeypatch = pytest.MonkeyPatch()
+        original_create = (
+            response_unmarshaller.schema_unmarshallers_factory.create
+        )
+
+        def spy_create(*args, **kwargs):
+            schema_unmarshaller = original_create(*args, **kwargs)
+            original_method = (
+                schema_unmarshaller.schema_validator.validate_state
+            )
+
+            def spy_validate_state(value):
+                calls.append(schema_unmarshaller.schema)
+                return original_method(value)
+
+            monkeypatch.setattr(
+                schema_unmarshaller.schema_validator,
+                "validate_state",
+                spy_validate_state,
+            )
+            return schema_unmarshaller
+
+        monkeypatch.setattr(
+            response_unmarshaller.schema_unmarshallers_factory,
+            "create",
+            spy_create,
+        )
+        try:
+            result = response_unmarshaller.unmarshal(request, response)
+        finally:
+            monkeypatch.undo()
+
+        assert result.errors == []
+        assert len(calls) == 1

--- a/tests/unit/deserializing/test_media_types_deserializers.py
+++ b/tests/unit/deserializing/test_media_types_deserializers.py
@@ -707,6 +707,56 @@ class TestMediaTypeDeserializer:
             "file": b"\xff\xfe",
         }
 
+    def test_multipart_oneof_string_field(self, spec, deserializer_factory):
+        mimetype = "multipart/form-data"
+        schema_dict = {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "typeA": {"type": "string"},
+                        "fieldA": {"type": "string"},
+                    },
+                    "required": ["typeA", "fieldA"],
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "typeB": {"type": "string"},
+                        "fieldB": {"type": "string"},
+                    },
+                    "required": ["typeB", "fieldB"],
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        parameters = {
+            "boundary": "===============2872712225071193122==",
+        }
+        deserializer = deserializer_factory(
+            mimetype,
+            schema=schema,
+            schema_validator=schema_validator,
+            parameters=parameters,
+        )
+        value = (
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: text/plain\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="typeA"\n\ntest\n'
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: text/plain\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="fieldA"\n\nvalue\n'
+            b"--===============2872712225071193122==--\n"
+        )
+
+        result = deserializer.deserialize(value)
+
+        assert result == {
+            "typeA": "test",
+            "fieldA": "value",
+        }
+
     @pytest.mark.xfail(
         reason=(
             "multipart composed-schema branch selection is not binary-aware"
@@ -740,6 +790,167 @@ class TestMediaTypeDeserializer:
             mimetype,
             schema=schema,
             schema_validator=schema_validator,
+            parameters=parameters,
+        )
+        value = (
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: application/octet-stream\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="file"\n\n\xff\xfe\n'
+            b"--===============2872712225071193122==--\n"
+        )
+
+        result = deserializer.deserialize(value)
+
+        assert result == {
+            "file": b"\xff\xfe",
+        }
+
+    def test_multipart_oneof_integer_field_with_form_encoding(
+        self, spec, deserializer_factory
+    ):
+        mimetype = "multipart/form-data"
+        schema_dict = {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "typeA": {"type": "string"},
+                        "fieldA": {"type": "string"},
+                    },
+                    "required": ["typeA", "fieldA"],
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "typeB": {"type": "string"},
+                        "fieldB": {"type": "integer"},
+                    },
+                    "required": ["typeB", "fieldB"],
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        encoding = SchemaPath.from_dict(
+            {
+                "typeB": {"style": "form"},
+                "fieldB": {"style": "form"},
+            }
+        )
+        parameters = {
+            "boundary": "===============2872712225071193122==",
+        }
+        deserializer = deserializer_factory(
+            mimetype,
+            schema=schema,
+            schema_validator=schema_validator,
+            encoding=encoding,
+            parameters=parameters,
+        )
+        value = (
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: text/plain\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="typeB"\n\ntest\n'
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: text/plain\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="fieldB"\n\n123\n'
+            b"--===============2872712225071193122==--\n"
+        )
+
+        result = deserializer.deserialize(value)
+
+        assert result == {
+            "typeB": "test",
+            "fieldB": 123,
+        }
+
+    def test_multipart_anyof_with_form_types(self, spec, deserializer_factory):
+        mimetype = "multipart/form-data"
+        schema_dict = {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "count": {"type": "integer"},
+                        "active": {"type": "boolean"},
+                    },
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                    },
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        encoding = SchemaPath.from_dict(
+            {
+                "count": {"style": "form"},
+                "active": {"style": "form"},
+                "name": {"style": "form"},
+            }
+        )
+        parameters = {
+            "boundary": "===============2872712225071193122==",
+        }
+        deserializer = deserializer_factory(
+            mimetype,
+            schema=schema,
+            schema_validator=schema_validator,
+            encoding=encoding,
+            parameters=parameters,
+        )
+        value = (
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: text/plain\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="count"\n\n42\n'
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: text/plain\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="active"\n\ntrue\n'
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: text/plain\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="name"\n\ntest\n'
+            b"--===============2872712225071193122==--\n"
+        )
+
+        result = deserializer.deserialize(value)
+
+        assert result == {
+            "count": 42,
+            "active": True,
+            "name": "test",
+        }
+
+    def test_multipart_form_binary_with_form_encoding_stays_bytes(
+        self, spec, deserializer_factory
+    ):
+        mimetype = "multipart/form-data"
+        schema_dict = {
+            "type": "object",
+            "properties": {
+                "file": {
+                    "type": "string",
+                    "format": "binary",
+                },
+            },
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        encoding = SchemaPath.from_dict(
+            {
+                "file": {"style": "form"},
+            }
+        )
+        parameters = {
+            "boundary": "===============2872712225071193122==",
+        }
+        deserializer = deserializer_factory(
+            mimetype,
+            schema=schema,
+            schema_validator=schema_validator,
+            encoding=encoding,
             parameters=parameters,
         )
         value = (

--- a/tests/unit/unmarshalling/test_schema_unmarshallers.py
+++ b/tests/unit/unmarshalling/test_schema_unmarshallers.py
@@ -11,11 +11,13 @@ from openapi_core.unmarshalling.schemas.exceptions import (
 from openapi_core.unmarshalling.schemas.factories import (
     SchemaUnmarshallersFactory,
 )
+from openapi_core.unmarshalling.schemas.unmarshallers import SchemaUnmarshaller
 from openapi_core.validation.schemas import (
     oas30_write_schema_validators_factory,
 )
 from openapi_core.validation.schemas.exceptions import InvalidSchemaValue
 from openapi_core.validation.schemas.factories import SchemaValidatorsFactory
+from openapi_core.validation.schemas.validators import SchemaValidator
 
 
 @pytest.fixture
@@ -259,3 +261,277 @@ class TestOAS30SchemaUnmarshallerUnmarshal:
         result = unmarshaller.unmarshal(value)
 
         assert result == value
+
+    def test_unmarshal_state_skips_repeat_validation(
+        self,
+        schema_unmarshaller_factory,
+    ):
+        schema = {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {"type": "integer"},
+                }
+            },
+        }
+        spec = SchemaPath.from_dict(schema)
+        value = {"items": [1, 2, 3]}
+        unmarshaller = schema_unmarshaller_factory(
+            oas30_write_schema_validators_factory,
+            spec,
+        )
+        assert isinstance(unmarshaller, SchemaUnmarshaller)
+
+        validate_state_spy = pytest.MonkeyPatch()
+        calls = []
+        original_validate_state = unmarshaller.schema_validator.validate_state
+
+        def spy_validate_state(inner_value):
+            calls.append(inner_value)
+            return original_validate_state(inner_value)
+
+        validate_state_spy.setattr(
+            unmarshaller.schema_validator,
+            "validate_state",
+            spy_validate_state,
+        )
+        try:
+            state = original_validate_state(value)
+            result = unmarshaller.unmarshal_state(state)
+        finally:
+            validate_state_spy.undo()
+
+        assert result == {"items": [1, 2, 3]}
+        assert calls == []
+
+    def test_unmarshal_state_reuses_composed_schema_selection_for_properties(
+        self,
+        schema_unmarshaller_factory,
+        monkeypatch,
+    ):
+        schema = {
+            "type": "object",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": ["kind", "created_at"],
+                    "properties": {
+                        "kind": {"type": "string"},
+                        "created_at": {
+                            "type": "string",
+                            "format": "date",
+                        },
+                    },
+                },
+                {
+                    "type": "object",
+                    "required": ["kind", "count"],
+                    "properties": {
+                        "kind": {"type": "string"},
+                        "count": {"type": "integer"},
+                    },
+                },
+            ],
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "count": {"type": "integer"},
+                    },
+                }
+            ],
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "kind": {"type": "string"},
+                    },
+                }
+            ],
+        }
+        spec = SchemaPath.from_dict(schema)
+        value = {
+            "kind": "counted",
+            "count": 3,
+        }
+        unmarshaller = schema_unmarshaller_factory(
+            oas30_write_schema_validators_factory,
+            spec,
+        )
+        assert isinstance(unmarshaller, SchemaUnmarshaller)
+
+        state = unmarshaller.schema_validator.validate_state(value)
+
+        monkeypatch.setattr(
+            SchemaValidator,
+            "get_one_of_schema",
+            lambda self, value, caster=None: (_ for _ in ()).throw(
+                AssertionError("oneOf recomputed during unmarshal_state")
+            ),
+        )
+        monkeypatch.setattr(
+            SchemaValidator,
+            "iter_any_of_schemas",
+            lambda self, value, caster=None: (_ for _ in ()).throw(
+                AssertionError("anyOf recomputed during unmarshal_state")
+            ),
+        )
+        monkeypatch.setattr(
+            SchemaValidator,
+            "iter_all_of_schemas",
+            lambda self, value: (_ for _ in ()).throw(
+                AssertionError("allOf recomputed during unmarshal_state")
+            ),
+        )
+
+        result = unmarshaller.unmarshal_state(state)
+
+        assert result == {"kind": "counted", "count": 3}
+
+    def test_unmarshal_state_reuses_composed_schema_selection_for_format(
+        self,
+        schema_unmarshaller_factory,
+        monkeypatch,
+    ):
+        schema = {
+            "oneOf": [
+                {"type": "integer"},
+                {
+                    "type": "string",
+                    "format": "date",
+                },
+            ],
+        }
+        spec = SchemaPath.from_dict(schema)
+        value = "2018-01-02"
+        unmarshaller = schema_unmarshaller_factory(
+            oas30_write_schema_validators_factory,
+            spec,
+        )
+        assert isinstance(unmarshaller, SchemaUnmarshaller)
+
+        state = unmarshaller.schema_validator.validate_state(value)
+
+        monkeypatch.setattr(
+            SchemaValidator,
+            "iter_valid_schemas",
+            lambda self, value: (_ for _ in ()).throw(
+                AssertionError(
+                    "valid schemas recomputed during unmarshal_state"
+                )
+            ),
+        )
+
+        result = unmarshaller.unmarshal_state(state)
+
+        assert result == value
+
+    def test_unmarshal_state_reuses_additional_properties_state(
+        self,
+        schema_unmarshaller_factory,
+        monkeypatch,
+    ):
+        schema = {
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": {"type": "integer"},
+                },
+            },
+        }
+        spec = SchemaPath.from_dict(schema)
+        value = {
+            "extras": [{"a": 1}, {"b": 2}],
+        }
+        unmarshaller = schema_unmarshaller_factory(
+            oas30_write_schema_validators_factory,
+            spec,
+        )
+        assert isinstance(unmarshaller, SchemaUnmarshaller)
+
+        state = unmarshaller.schema_validator.validate_state(value)
+
+        monkeypatch.setattr(
+            SchemaValidator,
+            "validate_state",
+            lambda self, value: (_ for _ in ()).throw(
+                AssertionError(
+                    "additionalProperties revalidated during unmarshal_state"
+                )
+            ),
+        )
+
+        result = unmarshaller.unmarshal_state(state)
+
+        assert result == value
+
+    def test_validate_state_only_checks_composed_schemas_where_declared(
+        self,
+        schema_unmarshaller_factory,
+        monkeypatch,
+    ):
+        schema = {
+            "type": "object",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": ["kind", "payload"],
+                    "properties": {
+                        "kind": {"type": "string"},
+                        "payload": {
+                            "type": "object",
+                            "oneOf": [
+                                {
+                                    "type": "object",
+                                    "required": ["count"],
+                                    "properties": {
+                                        "count": {"type": "integer"},
+                                    },
+                                },
+                                {
+                                    "type": "object",
+                                    "required": ["label"],
+                                    "properties": {
+                                        "label": {"type": "string"},
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                }
+            ],
+        }
+        spec = SchemaPath.from_dict(schema)
+        value = {
+            "kind": "counted",
+            "payload": {"count": 3},
+        }
+        unmarshaller = schema_unmarshaller_factory(
+            oas30_write_schema_validators_factory,
+            spec,
+        )
+        assert isinstance(unmarshaller, SchemaUnmarshaller)
+
+        original_get_one_of_schema = SchemaValidator.get_one_of_schema
+        calls = []
+
+        def spy_get_one_of_schema(self, inner_value, caster=None):
+            calls.append(inner_value)
+            return original_get_one_of_schema(self, inner_value, caster=caster)
+
+        monkeypatch.setattr(
+            SchemaValidator,
+            "get_one_of_schema",
+            spy_get_one_of_schema,
+        )
+
+        state = unmarshaller.schema_validator.validate_state(value)
+
+        assert state.one_of_state is not None
+        assert calls == [
+            {"kind": "counted", "payload": {"count": 3}},
+            {"count": 3},
+        ]


### PR DESCRIPTION
`ValidationState` with composition keywords to cache branch selection and avoid re-resolving it at unmarshal time.

- Remove duplicate schema validation during unmarshalling by introducing an internal trusted `ValidationState` path and reusing it through nested/composed schemas.
- Add regression coverage to confirm request and response body schemas are validated only once during unmarshal.
- Extend multipart form deserialization to correctly resolve `oneOf`/`anyOf` branches with typed form fields, including preserving encoding metadata and normalizing multipart form values before casting.


variant | median | ops/s | vs master
-- | -- | -- | --
master | 3.37s | 297 | —
feature | 2.67s | 375 | −20.5% faster

