### PR TITLE
Add xfail coverage for multipart binary composed-schema matching

### DIFF
--- a/tests/integration/unmarshalling/test_request_unmarshaller.py
+++ b/tests/integration/unmarshalling/test_request_unmarshaller.py
@@ -1,5 +1,6 @@
 import json
 from base64 import b64encode
+from email.generator import _make_boundary
 
 import pytest
 
@@ -467,3 +468,79 @@ class TestRequestUnmarshaller:
 
         assert result.errors == []
         assert result.body == {"tags": []}
+
+    @pytest.mark.xfail(
+        reason=(
+            "multipart composed-schema branch selection is not binary-aware"
+        ),
+        strict=True,
+    )
+    def test_request_body_multipart_oneof_binary_field(self):
+        from openapi_core import OpenAPI
+
+        boundary = _make_boundary()
+        spec = OpenAPI.from_dict(
+            {
+                "openapi": "3.1.0",
+                "info": {"version": "0", "title": "test"},
+                "paths": {
+                    "/test": {
+                        "post": {
+                            "requestBody": {
+                                "required": True,
+                                "content": {
+                                    "multipart/form-data": {
+                                        "schema": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "label": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["label"],
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "file": {
+                                                            "type": "string",
+                                                            "format": "binary",
+                                                        }
+                                                    },
+                                                    "required": ["file"],
+                                                },
+                                            ]
+                                        }
+                                    }
+                                },
+                            },
+                            "responses": {"200": {"description": ""}},
+                        }
+                    }
+                },
+            }
+        )
+        data = (
+            (
+                f"--{boundary}\n"
+                "Content-Type: application/octet-stream\n"
+                "MIME-Version: 1.0\n"
+                'Content-Disposition: form-data; name="file"\n\n'
+            ).encode("ascii")
+            + b"\xff\xfe\n"
+            + (f"--{boundary}--\n").encode("ascii")
+        )
+        request = MockRequest(
+            "http://localhost",
+            "post",
+            "/test",
+            content_type=f"multipart/form-data; boundary={boundary}",
+            data=data,
+        )
+
+        result = spec.unmarshal_request(request)
+
+        assert result.errors == []
+        assert result.body == {"file": b"\xff\xfe"}

--- a/tests/unit/deserializing/test_media_types_deserializers.py
+++ b/tests/unit/deserializing/test_media_types_deserializers.py
@@ -656,3 +656,101 @@ class TestMediaTypeDeserializer:
         result = deserializer.deserialize(value)
 
         assert result == {"tags": []}
+
+    @pytest.mark.xfail(
+        reason=(
+            "multipart composed-schema branch selection is not binary-aware"
+        ),
+        strict=True,
+    )
+    def test_multipart_oneof_binary_field(self, spec, deserializer_factory):
+        mimetype = "multipart/form-data"
+        schema_dict = {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "label": {"type": "string"},
+                    },
+                    "required": ["label"],
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "file": {"type": "string", "format": "binary"},
+                    },
+                    "required": ["file"],
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        parameters = {
+            "boundary": "===============2872712225071193122==",
+        }
+        deserializer = deserializer_factory(
+            mimetype,
+            schema=schema,
+            schema_validator=schema_validator,
+            parameters=parameters,
+        )
+        value = (
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: application/octet-stream\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="file"\n\n\xff\xfe\n'
+            b"--===============2872712225071193122==--\n"
+        )
+
+        result = deserializer.deserialize(value)
+
+        assert result == {
+            "file": b"\xff\xfe",
+        }
+
+    @pytest.mark.xfail(
+        reason=(
+            "multipart composed-schema branch selection is not binary-aware"
+        ),
+        strict=True,
+    )
+    def test_multipart_anyof_binary_field(self, spec, deserializer_factory):
+        mimetype = "multipart/form-data"
+        schema_dict = {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "file": {"type": "string", "format": "binary"},
+                    },
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "label": {"type": "string"},
+                    },
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        parameters = {
+            "boundary": "===============2872712225071193122==",
+        }
+        deserializer = deserializer_factory(
+            mimetype,
+            schema=schema,
+            schema_validator=schema_validator,
+            parameters=parameters,
+        )
+        value = (
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: application/octet-stream\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="file"\n\n\xff\xfe\n'
+            b"--===============2872712225071193122==--\n"
+        )
+
+        result = deserializer.deserialize(value)
+
+        assert result == {
+            "file": b"\xff\xfe",
+        }


### PR DESCRIPTION
- Add unit and integration xfail coverage for multipart oneOf/anyOf request bodies that distinguish branches using string fields with format: binary.
- Document the current limitation that multipart composed-schema branch selection is not yet binary-aware.