### PR TITLE
Fix multipart binary/urlencoded composed-schema matching

### DIFF
--- a/openapi_core/deserializing/media_types/deserializers.py
+++ b/openapi_core/deserializing/media_types/deserializers.py
@@ -223,10 +223,68 @@ class MediaTypeDeserializer:
         if self.schema is None or "oneOf" not in self.schema:
             return None
 
+        matches: list[FormMediaSchemaMatch] = []
         for subschema in self.schema / "oneOf":
             match = self.get_form_media_schema_match(subschema, location)
             if match is not None:
-                return match
+                matches.append(match)
+
+        if len(matches) == 1:
+            return matches[0]
+
+        return self.get_preferred_form_media_one_of_match(matches)
+
+    def get_preferred_form_media_one_of_match(
+        self,
+        matches: list[FormMediaSchemaMatch],
+    ) -> Optional[FormMediaSchemaMatch]:
+        if len(matches) < 2:
+            return None
+
+        preferred_match = matches[0]
+        for match in matches[1:]:
+            preferred_match = self.prefer_form_media_one_of_match(
+                preferred_match,
+                match,
+            )
+            if preferred_match is None:
+                return None
+
+        return preferred_match
+
+    def prefer_form_media_one_of_match(
+        self,
+        current: FormMediaSchemaMatch,
+        new: FormMediaSchemaMatch,
+    ) -> Optional[FormMediaSchemaMatch]:
+        current_keys = set(current.decoded_candidate)
+        new_keys = set(new.decoded_candidate)
+        if current_keys != new_keys:
+            return None
+
+        preferred = current
+        preferred_has_binary = False
+
+        for prop_name in current_keys:
+            current_value = current.decoded_candidate[prop_name]
+            new_value = new.decoded_candidate[prop_name]
+
+            if current_value == new_value:
+                continue
+
+            if isinstance(current_value, bytes) and isinstance(new_value, str):
+                preferred_has_binary = True
+                continue
+
+            if isinstance(current_value, str) and isinstance(new_value, bytes):
+                preferred = new
+                preferred_has_binary = True
+                continue
+
+            return None
+
+        if preferred_has_binary:
+            return preferred
 
         return None
 

--- a/openapi_core/deserializing/media_types/deserializers.py
+++ b/openapi_core/deserializing/media_types/deserializers.py
@@ -1,11 +1,14 @@
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Any
+from typing import Iterator
 from typing import Mapping
 from typing import Optional
 from xml.etree.ElementTree import ParseError
 
 from jsonschema_path import SchemaPath
 
+from openapi_core.deserializing.exceptions import DeserializeError
 from openapi_core.deserializing.media_types.datatypes import (
     DeserializerCallable,
 )
@@ -23,6 +26,7 @@ from openapi_core.schema.parameters import get_style_and_explode
 from openapi_core.schema.protocols import SuportsGetAll
 from openapi_core.schema.protocols import SuportsGetList
 from openapi_core.schema.schemas import get_properties
+from openapi_core.validation.schemas.exceptions import ValidateError
 from openapi_core.validation.schemas.validators import SchemaValidator
 
 if TYPE_CHECKING:
@@ -63,6 +67,12 @@ class MediaTypesDeserializer:
         return self.media_type_deserializers[mimetype]
 
 
+@dataclass(frozen=True)
+class FormMediaSchemaMatch:
+    schema: SchemaPath
+    decoded_candidate: Mapping[str, Any]
+
+
 class MediaTypeDeserializer:
     def __init__(
         self,
@@ -97,7 +107,7 @@ class MediaTypeDeserializer:
         ):
             return deserialized
 
-        # decode multipart request bodies if schema provided
+        # Decode form-media bodies only when a schema is available.
         if self.schema is not None:
             return self.decode(deserialized)
 
@@ -126,43 +136,42 @@ class MediaTypeDeserializer:
             schema=schema,
             schema_validator=schema_validator,
             schema_caster=schema_caster,
+            encoding=self.encoding,
+            **self.parameters,
         )
 
     def decode(
-        self, location: Mapping[str, Any], schema_only: bool = False
+        self,
+        location: Mapping[str, Any],
+        schema_only: bool = False,
+        use_defaults: bool = True,
     ) -> Mapping[str, Any]:
-        # schema is required for multipart
+        # Form-media decoding always needs a schema to resolve properties.
         assert self.schema is not None
         properties: dict[str, Any] = {}
 
-        # For urlencoded/multipart, use caster for oneOf/anyOf detection if validator available
+        # For form media, select composed branches from decoded candidates.
         if self.schema_validator is not None:
-            one_of_schema = self.schema_validator.get_one_of_schema(
-                location, caster=self.schema_caster
-            )
-            if one_of_schema is not None:
-                one_of_properties = self.evolve(one_of_schema).decode(
-                    location, schema_only=True
+            one_of_match = self.get_form_media_one_of_match(location)
+            if one_of_match is not None:
+                self.update_decoded_properties(
+                    properties,
+                    one_of_match.decoded_candidate,
                 )
-                properties.update(one_of_properties)
 
-            any_of_schemas = self.schema_validator.iter_any_of_schemas(
-                location, caster=self.schema_caster
-            )
-            for any_of_schema in any_of_schemas:
-                any_of_properties = self.evolve(any_of_schema).decode(
-                    location, schema_only=True
+            any_of_matches = self.iter_form_media_any_of_matches(location)
+            for any_of_match in any_of_matches:
+                self.update_decoded_properties(
+                    properties,
+                    any_of_match.decoded_candidate,
                 )
-                properties.update(any_of_properties)
 
-            all_of_schemas = self.schema_validator.iter_all_of_schemas(
-                location
-            )
-            for all_of_schema in all_of_schemas:
-                all_of_properties = self.evolve(all_of_schema).decode(
-                    location, schema_only=True
+            all_of_matches = self.iter_form_media_all_of_matches(location)
+            for all_of_match in all_of_matches:
+                self.update_decoded_properties(
+                    properties,
+                    all_of_match.decoded_candidate,
                 )
-                properties.update(all_of_properties)
 
         for prop_name, prop_schema in get_properties(self.schema).items():
             try:
@@ -170,7 +179,7 @@ class MediaTypeDeserializer:
                     prop_name, prop_schema, location
                 )
             except KeyError:
-                if "default" not in prop_schema:
+                if not use_defaults or "default" not in prop_schema:
                     continue
                 properties[prop_name] = (prop_schema / "default").read_value()
 
@@ -178,6 +187,108 @@ class MediaTypeDeserializer:
             return properties
 
         return properties
+
+    def update_decoded_properties(
+        self,
+        properties: dict[str, Any],
+        candidate: Mapping[str, Any],
+    ) -> None:
+        for prop_name, prop_value in candidate.items():
+            if prop_name not in properties:
+                properties[prop_name] = prop_value
+                continue
+
+            properties[prop_name] = self.merge_decoded_property_value(
+                properties[prop_name],
+                prop_value,
+            )
+
+    def merge_decoded_property_value(self, current: Any, new: Any) -> Any:
+        if current == new:
+            return current
+
+        # Prefer lossless binary values over surrogate-decoded text when
+        # overlapping composed branches describe the same multipart field.
+        if isinstance(current, bytes) and isinstance(new, str):
+            return current
+        if isinstance(current, str) and isinstance(new, bytes):
+            return new
+
+        return new
+
+    def get_form_media_one_of_match(
+        self,
+        location: Mapping[str, Any],
+    ) -> Optional[FormMediaSchemaMatch]:
+        if self.schema is None or "oneOf" not in self.schema:
+            return None
+
+        for subschema in self.schema / "oneOf":
+            match = self.get_form_media_schema_match(subschema, location)
+            if match is not None:
+                return match
+
+        return None
+
+    def iter_form_media_any_of_matches(
+        self,
+        location: Mapping[str, Any],
+    ) -> list[FormMediaSchemaMatch]:
+        if self.schema is None or "anyOf" not in self.schema:
+            return []
+
+        return list(self.iter_form_media_schema_matches("anyOf", location))
+
+    def iter_form_media_all_of_matches(
+        self,
+        location: Mapping[str, Any],
+    ) -> list[FormMediaSchemaMatch]:
+        if self.schema is None or "allOf" not in self.schema:
+            return []
+
+        return list(self.iter_form_media_schema_matches("allOf", location))
+
+    def iter_form_media_schema_matches(
+        self,
+        keyword: str,
+        location: Mapping[str, Any],
+    ) -> Iterator[FormMediaSchemaMatch]:
+        assert self.schema is not None
+
+        for subschema in self.schema / keyword:
+            match = self.get_form_media_schema_match(subschema, location)
+            if match is not None:
+                yield match
+
+    def get_form_media_schema_match(
+        self,
+        subschema: SchemaPath,
+        location: Mapping[str, Any],
+    ) -> Optional[FormMediaSchemaMatch]:
+        assert self.schema_validator is not None
+
+        deserializer = self.evolve(subschema)
+        try:
+            validation_decoded_candidate = deserializer.decode(
+                location,
+                schema_only=True,
+                use_defaults=False,
+            )
+        except DeserializeError:
+            return None
+
+        validator = self.schema_validator.evolve(subschema)
+        validation_candidate = dict(location)
+        validation_candidate.update(validation_decoded_candidate)
+
+        try:
+            validator.validate(validation_candidate)
+        except ValidateError:
+            return None
+
+        decoded_candidate = deserializer.decode(location, schema_only=True)
+
+        return FormMediaSchemaMatch(subschema, decoded_candidate)
 
     def decode_property(
         self,

--- a/openapi_core/unmarshalling/unmarshallers.py
+++ b/openapi_core/unmarshalling/unmarshallers.py
@@ -117,7 +117,7 @@ class BaseUnmarshaller(BaseValidator):
     def _get_content_and_schema(
         self, raw: Any, content: SchemaPath, mimetype: Optional[str] = None
     ) -> Tuple[Any, Optional[SchemaPath]]:
-        casted, schema = super()._get_content_and_schema(
+        casted, schema = self._get_content_schema_value_and_schema(
             raw, content, mimetype
         )
         if schema is None:

--- a/openapi_core/validation/schemas/validators.py
+++ b/openapi_core/validation/schemas/validators.py
@@ -294,31 +294,15 @@ class SchemaValidator:
         if "oneOf" not in self.schema:
             return None
 
-        one_of_schemas = self.schema / "oneOf"
-        for subschema in one_of_schemas:
-            validator = self.evolve(subschema)
-            try:
-                test_value = value
-                # Only cast if caster provided (opt-in behavior)
-                if caster is not None:
-                    try:
-                        # Convert to dict if it's not exactly a plain dict
-                        # (e.g., ImmutableMultiDict from werkzeug)
-                        if type(value) is not dict:
-                            test_value = dict(value)
-                        else:
-                            test_value = value
-                        test_value = caster.evolve(subschema).cast(test_value)
-                    except (ValueError, TypeError, Exception):
-                        # If casting fails, try validation with original value
-                        # We catch generic Exception to handle CastError without circular import
-                        test_value = value
-
-                validator.validate(test_value)
-            except ValidateError:
-                continue
-            else:
-                return subschema
+        matched_schemas = list(
+            self.iter_matching_composed_schemas(
+                "oneOf",
+                value,
+                caster=caster,
+            )
+        )
+        if len(matched_schemas) == 1:
+            return matched_schemas[0]
 
         log.warning("valid oneOf schema not found")
         return None

--- a/openapi_core/validation/schemas/validators.py
+++ b/openapi_core/validation/schemas/validators.py
@@ -1,12 +1,16 @@
 import logging
+from copy import deepcopy
 from functools import cached_property
 from functools import partial
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Iterator
 from typing import Optional
+from typing import Union
+from typing import cast
 
 from jsonschema.exceptions import FormatError
+from jsonschema.exceptions import ValidationError
 from jsonschema.protocols import Validator
 from jsonschema_path import SchemaPath
 
@@ -18,6 +22,9 @@ if TYPE_CHECKING:
     from openapi_core.casting.schemas.casters import SchemaCaster
 
 log = logging.getLogger(__name__)
+
+
+_MISSING = object()
 
 
 class SchemaValidator:
@@ -33,11 +40,27 @@ class SchemaValidator:
         return schema_format in self.validator.format_checker.checkers
 
     def validate(self, value: Any) -> None:
-        errors_iter = self.validator.iter_errors(value)
-        errors = tuple(errors_iter)
+        validation_value = self.get_binary_validation_value(value)
+        errors = tuple(
+            self.iter_errors(
+                value,
+                validation_value=validation_value,
+            )
+        )
         if errors:
             schema_type = (self.schema / "type").read_str_or_list("any")
             raise InvalidSchemaValue(value, schema_type, schema_errors=errors)
+
+    def iter_errors(
+        self,
+        value: Any,
+        validation_value: Any = _MISSING,
+    ) -> Iterator[Exception]:
+        if validation_value is _MISSING:
+            validation_value = self.get_binary_validation_value(value)
+
+        yield from self.base_validator.iter_errors(validation_value)
+        yield from self.iter_composed_schema_errors(value)
 
     def evolve(self, schema: SchemaPath) -> "SchemaValidator":
         cls = self.__class__
@@ -47,6 +70,16 @@ class SchemaValidator:
                 schema=resolved.contents, _resolver=resolved.resolver
             )
             return cls(schema, validator)
+
+    @cached_property
+    def base_validator(self) -> Validator:
+        with self.schema.resolve() as resolved:
+            schema = cast(dict[str, Any], deepcopy(resolved.contents))
+
+        for keyword in ["oneOf", "anyOf", "allOf"]:
+            schema.pop(keyword, None)
+
+        return self.validator.evolve(schema=schema)
 
     def type_validator(
         self, value: Any, type_override: Optional[str] = None
@@ -93,6 +126,8 @@ class SchemaValidator:
             schema_types = sorted(self.validator.TYPE_CHECKER._type_checkers)
         assert isinstance(schema_types, list)
         for schema_type in schema_types:
+            if self.accepts_binary_string_value(schema_type, value):
+                return schema_type
             result = self.type_validator(value, type_override=schema_type)
             if not result:
                 continue
@@ -103,6 +138,136 @@ class SchemaValidator:
             return schema_type
         # OpenAPI 3.0: None is not a primitive type so None value will not find any type
         return None
+
+    def accepts_binary_string_value(
+        self,
+        schema_type: Optional[Union[str, list[str]]],
+        value: Any,
+    ) -> bool:
+        if not isinstance(value, bytes):
+            return False
+
+        if isinstance(schema_type, list):
+            if "string" not in schema_type:
+                return False
+        elif schema_type != "string":
+            return False
+
+        schema_format = (self.schema / "format").read_str(None)
+        return schema_format in ("binary", "byte")
+
+    def get_binary_validation_value(self, value: Any) -> Any:
+        # OpenAPI binary and byte string values are represented as bytes,
+        # but jsonschema validates string schemas against text values.
+        if self.accepts_binary_string_value(
+            (self.schema / "type").read_str_or_list(None), value
+        ):
+            return self.decode_binary_string_value(value)
+
+        normalized = value
+
+        if isinstance(normalized, dict):
+            return self.get_binary_validation_mapping_value(normalized)
+
+        if isinstance(normalized, list) and "items" in self.schema:
+            return self.get_binary_validation_array_value(normalized)
+
+        return normalized
+
+    def iter_composed_schema_errors(
+        self, value: Any
+    ) -> Iterator[ValidationError]:
+        if "oneOf" in self.schema:
+            matched_schemas = list(
+                self.iter_matching_composed_schemas("oneOf", value)
+            )
+            if len(matched_schemas) != 1:
+                if not matched_schemas:
+                    message = f"{value!r} is not valid under any of the given schemas"
+                else:
+                    message = (
+                        f"{value!r} is valid under each of {matched_schemas!r}"
+                    )
+                yield ValidationError(message)
+
+        if "anyOf" in self.schema:
+            matched_schemas = list(
+                self.iter_matching_composed_schemas("anyOf", value)
+            )
+            if not matched_schemas:
+                yield ValidationError(
+                    f"{value!r} is not valid under any of the given schemas"
+                )
+
+        if "allOf" in self.schema:
+            invalid_schemas = list(self.iter_invalid_all_of_schemas(value))
+            for _ in invalid_schemas:
+                yield ValidationError(
+                    f"{value!r} is not valid under all of the given schemas"
+                )
+
+    def decode_binary_string_value(self, value: bytes) -> str:
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError:
+            return value.decode("ASCII", errors="surrogateescape")
+
+    def get_binary_validation_mapping_value(self, value: Any) -> Any:
+        normalized = value
+
+        if "properties" in self.schema:
+            for prop_name, prop_schema in (self.schema / "properties").items():
+                if prop_name not in value:
+                    continue
+                prop_value = self.evolve(
+                    prop_schema
+                ).get_binary_validation_value(value[prop_name])
+                if prop_value is value[prop_name]:
+                    continue
+                if normalized is value:
+                    normalized = dict(value)
+                normalized[prop_name] = prop_value
+
+        additional_properties = self.schema.get("additionalProperties", True)
+        if additional_properties in (True, False):
+            return normalized
+
+        property_names = set()
+        if "properties" in self.schema:
+            property_names = set((self.schema / "properties").keys())
+        additional_validator = self.evolve(
+            self.schema / "additionalProperties"
+        )
+        for prop_name, prop_value in value.items():
+            if prop_name in property_names:
+                continue
+            normalized_prop_value = (
+                additional_validator.get_binary_validation_value(prop_value)
+            )
+            if normalized_prop_value is prop_value:
+                continue
+            if normalized is value:
+                normalized = dict(value)
+            normalized[prop_name] = normalized_prop_value
+
+        return normalized
+
+    def get_binary_validation_array_value(self, value: Any) -> Any:
+        item_validator = self.evolve(self.schema / "items")
+        normalized = None
+
+        for idx, item in enumerate(value):
+            normalized_item = item_validator.get_binary_validation_value(item)
+            if normalized_item is item:
+                continue
+            if normalized is None:
+                normalized = list(value)
+            normalized[idx] = normalized_item
+
+        if normalized is None:
+            return value
+
+        return normalized
 
     def iter_valid_schemas(self, value: Any) -> Iterator[SchemaPath]:
         yield self.schema
@@ -158,6 +323,35 @@ class SchemaValidator:
         log.warning("valid oneOf schema not found")
         return None
 
+    def iter_matching_composed_schemas(
+        self,
+        keyword: str,
+        value: Any,
+        caster: Optional["SchemaCaster"] = None,
+    ) -> Iterator[SchemaPath]:
+        if keyword not in self.schema:
+            return
+
+        for subschema in self.schema / keyword:
+            validator = self.evolve(subschema)
+            try:
+                test_value = value
+                if caster is not None:
+                    try:
+                        if type(value) is not dict:
+                            test_value = dict(value)
+                        else:
+                            test_value = value
+                        test_value = caster.evolve(subschema).cast(test_value)
+                    except (ValueError, TypeError, Exception):
+                        test_value = value
+
+                validator.validate(test_value)
+            except ValidateError:
+                continue
+            else:
+                yield subschema
+
     def iter_any_of_schemas(
         self,
         value: Any,
@@ -173,30 +367,11 @@ class SchemaValidator:
         if "anyOf" not in self.schema:
             return
 
-        any_of_schemas = self.schema / "anyOf"
-        for subschema in any_of_schemas:
-            validator = self.evolve(subschema)
-            try:
-                test_value = value
-                # Only cast if caster provided (opt-in behavior)
-                if caster is not None:
-                    try:
-                        # Convert to dict if it's not exactly a plain dict
-                        if type(value) is not dict:
-                            test_value = dict(value)
-                        else:
-                            test_value = value
-                        test_value = caster.evolve(subschema).cast(test_value)
-                    except (ValueError, TypeError, Exception):
-                        # If casting fails, try validation with original value
-                        # We catch generic Exception to handle CastError without circular import
-                        test_value = value
-
-                validator.validate(test_value)
-            except ValidateError:
-                continue
-            else:
-                yield subschema
+        yield from self.iter_matching_composed_schemas(
+            "anyOf",
+            value,
+            caster=caster,
+        )
 
     def iter_all_of_schemas(
         self,
@@ -205,14 +380,22 @@ class SchemaValidator:
         if "allOf" not in self.schema:
             return
 
-        all_of_schemas = self.schema / "allOf"
-        for subschema in all_of_schemas:
-            if "type" not in subschema:
-                continue
+        for subschema in self.schema / "allOf":
             validator = self.evolve(subschema)
             try:
                 validator.validate(value)
             except ValidateError:
                 log.warning("invalid allOf schema found")
             else:
+                yield subschema
+
+    def iter_invalid_all_of_schemas(self, value: Any) -> Iterator[SchemaPath]:
+        if "allOf" not in self.schema:
+            return
+
+        for subschema in self.schema / "allOf":
+            validator = self.evolve(subschema)
+            try:
+                validator.validate(value)
+            except ValidateError:
                 yield subschema

--- a/tests/integration/unmarshalling/test_request_unmarshaller.py
+++ b/tests/integration/unmarshalling/test_request_unmarshaller.py
@@ -1,6 +1,5 @@
 import json
 from base64 import b64encode
-from email.generator import _make_boundary
 
 import pytest
 
@@ -12,6 +11,7 @@ from openapi_core.templating.paths.exceptions import PathNotFound
 from openapi_core.templating.security.exceptions import SecurityNotFound
 from openapi_core.testing import MockRequest
 from openapi_core.validation.request.exceptions import InvalidParameter
+from openapi_core.validation.request.exceptions import InvalidRequestBody
 from openapi_core.validation.request.exceptions import MissingRequiredParameter
 from openapi_core.validation.request.exceptions import (
     MissingRequiredRequestBody,
@@ -469,16 +469,248 @@ class TestRequestUnmarshaller:
         assert result.errors == []
         assert result.body == {"tags": []}
 
+    def test_request_body_urlencoded_oneof_does_not_match_defaults_only(self):
+        from openapi_core import OpenAPI
+
+        spec = OpenAPI.from_dict(
+            {
+                "openapi": "3.1.0",
+                "info": {"version": "0", "title": "test"},
+                "paths": {
+                    "/test": {
+                        "post": {
+                            "requestBody": {
+                                "required": True,
+                                "content": {
+                                    "application/x-www-form-urlencoded": {
+                                        "schema": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "required": ["x"],
+                                                    "properties": {
+                                                        "x": {
+                                                            "type": "integer",
+                                                            "default": 1,
+                                                        }
+                                                    },
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "required": ["y"],
+                                                    "properties": {
+                                                        "y": {"type": "string"}
+                                                    },
+                                                },
+                                            ]
+                                        }
+                                    }
+                                },
+                            },
+                            "responses": {"200": {"description": ""}},
+                        }
+                    }
+                },
+            }
+        )
+        request = MockRequest(
+            "http://localhost",
+            "post",
+            "/test",
+            content_type="application/x-www-form-urlencoded",
+            data=b"=",
+        )
+
+        result = spec.unmarshal_request(request)
+
+        assert len(result.errors) == 1
+        assert type(result.errors[0]) == InvalidRequestBody
+        assert result.body is None
+
+    def test_request_body_urlencoded_allof_typeless_fragments(self):
+        from openapi_core import OpenAPI
+
+        spec = OpenAPI.from_dict(
+            {
+                "openapi": "3.1.0",
+                "info": {"version": "0", "title": "test"},
+                "paths": {
+                    "/test": {
+                        "post": {
+                            "requestBody": {
+                                "required": True,
+                                "content": {
+                                    "application/x-www-form-urlencoded": {
+                                        "schema": {
+                                            "type": "object",
+                                            "allOf": [
+                                                {
+                                                    "properties": {
+                                                        "a": {
+                                                            "type": "integer"
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "b": {
+                                                            "type": "boolean"
+                                                        }
+                                                    }
+                                                },
+                                            ],
+                                        }
+                                    }
+                                },
+                            },
+                            "responses": {"200": {"description": ""}},
+                        }
+                    }
+                },
+            }
+        )
+        request = MockRequest(
+            "http://localhost",
+            "post",
+            "/test",
+            content_type="application/x-www-form-urlencoded",
+            data=b"a=1&b=true",
+        )
+
+        result = spec.unmarshal_request(request)
+
+        assert result.errors == []
+        assert result.body == {"a": 1, "b": True}
+
     @pytest.mark.xfail(
         reason=(
-            "multipart composed-schema branch selection is not binary-aware"
+            "Form-media oneOf behavior is greedy and selects the first "
+            "matching branch instead of enforcing oneOf exclusivity"
         ),
         strict=True,
     )
+    def test_request_body_urlencoded_oneof_rejects_ambiguous_matches(self):
+        from openapi_core import OpenAPI
+
+        spec = OpenAPI.from_dict(
+            {
+                "openapi": "3.1.0",
+                "info": {"version": "0", "title": "test"},
+                "paths": {
+                    "/test": {
+                        "post": {
+                            "requestBody": {
+                                "required": True,
+                                "content": {
+                                    "application/x-www-form-urlencoded": {
+                                        "schema": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "required": ["a"],
+                                                    "properties": {
+                                                        "a": {"type": "string"}
+                                                    },
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "required": ["b"],
+                                                    "properties": {
+                                                        "b": {"type": "string"}
+                                                    },
+                                                },
+                                            ]
+                                        }
+                                    }
+                                },
+                            },
+                            "responses": {"200": {"description": ""}},
+                        }
+                    }
+                },
+            }
+        )
+        request = MockRequest(
+            "http://localhost",
+            "post",
+            "/test",
+            content_type="application/x-www-form-urlencoded",
+            data=b"a=x&b=y",
+        )
+
+        result = spec.unmarshal_request(request)
+
+        assert len(result.errors) == 1
+        assert type(result.errors[0]) == InvalidRequestBody
+        assert result.body is None
+
+    @pytest.mark.xfail(
+        reason=(
+            "Form-media validation accepts typeless allOf object "
+            "fragments without rejecting invalid submitted fields"
+        ),
+        strict=True,
+    )
+    def test_request_body_urlencoded_allof_does_not_drop_invalid_fields(self):
+        from openapi_core import OpenAPI
+
+        spec = OpenAPI.from_dict(
+            {
+                "openapi": "3.1.0",
+                "info": {"version": "0", "title": "test"},
+                "paths": {
+                    "/test": {
+                        "post": {
+                            "requestBody": {
+                                "required": True,
+                                "content": {
+                                    "application/x-www-form-urlencoded": {
+                                        "schema": {
+                                            "type": "object",
+                                            "allOf": [
+                                                {
+                                                    "properties": {
+                                                        "a": {
+                                                            "type": "integer"
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "properties": {
+                                                        "b": {
+                                                            "type": "boolean"
+                                                        }
+                                                    }
+                                                },
+                                            ],
+                                        }
+                                    }
+                                },
+                            },
+                            "responses": {"200": {"description": ""}},
+                        }
+                    }
+                },
+            }
+        )
+        request = MockRequest(
+            "http://localhost",
+            "post",
+            "/test",
+            content_type="application/x-www-form-urlencoded",
+            data=b"a=abc&b=true",
+        )
+
+        result = spec.unmarshal_request(request)
+
+        assert len(result.errors) == 1
+        assert type(result.errors[0]) == InvalidRequestBody
+        assert result.body is None
+
     def test_request_body_multipart_oneof_binary_field(self):
         from openapi_core import OpenAPI
 
-        boundary = _make_boundary()
+        boundary = "testboundary"
         spec = OpenAPI.from_dict(
             {
                 "openapi": "3.1.0",
@@ -544,3 +776,357 @@ class TestRequestUnmarshaller:
 
         assert result.errors == []
         assert result.body == {"file": b"\xff\xfe"}
+
+    def test_request_body_multipart_oneof_binary_field_over_plain_string_field(
+        self,
+    ):
+        from openapi_core import OpenAPI
+
+        boundary = "testboundary"
+        spec = OpenAPI.from_dict(
+            {
+                "openapi": "3.1.0",
+                "info": {"version": "0", "title": "test"},
+                "paths": {
+                    "/test": {
+                        "post": {
+                            "requestBody": {
+                                "required": True,
+                                "content": {
+                                    "multipart/form-data": {
+                                        "schema": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "file": {
+                                                            "type": "string",
+                                                            "format": "binary",
+                                                        }
+                                                    },
+                                                    "required": ["file"],
+                                                    "additionalProperties": False,
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "file": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["file"],
+                                                    "additionalProperties": False,
+                                                },
+                                            ]
+                                        }
+                                    }
+                                },
+                            },
+                            "responses": {"200": {"description": ""}},
+                        }
+                    }
+                },
+            }
+        )
+        data = (
+            (
+                f"--{boundary}\n"
+                "Content-Type: application/octet-stream\n"
+                "MIME-Version: 1.0\n"
+                'Content-Disposition: form-data; name="file"\n\n'
+            ).encode("ascii")
+            + b"\xff\xfe\n"
+            + (f"--{boundary}--\n").encode("ascii")
+        )
+        request = MockRequest(
+            "http://localhost",
+            "post",
+            "/test",
+            content_type=f"multipart/form-data; boundary={boundary}",
+            data=data,
+        )
+
+        result = spec.unmarshal_request(request)
+
+        assert result.errors == []
+        assert result.body == {"file": b"\xff\xfe"}
+
+    def test_request_body_multipart_anyof_binary_field_over_plain_string_field(
+        self,
+    ):
+        from openapi_core import OpenAPI
+
+        boundary = "testboundary"
+        spec = OpenAPI.from_dict(
+            {
+                "openapi": "3.1.0",
+                "info": {"version": "0", "title": "test"},
+                "paths": {
+                    "/test": {
+                        "post": {
+                            "requestBody": {
+                                "required": True,
+                                "content": {
+                                    "multipart/form-data": {
+                                        "schema": {
+                                            "anyOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "file": {
+                                                            "type": "string",
+                                                            "format": "binary",
+                                                        }
+                                                    },
+                                                    "required": ["file"],
+                                                    "additionalProperties": False,
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "file": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["file"],
+                                                    "additionalProperties": False,
+                                                },
+                                            ]
+                                        }
+                                    }
+                                },
+                            },
+                            "responses": {"200": {"description": ""}},
+                        }
+                    }
+                },
+            }
+        )
+        data = (
+            (
+                f"--{boundary}\n"
+                "Content-Type: application/octet-stream\n"
+                "MIME-Version: 1.0\n"
+                'Content-Disposition: form-data; name="file"\n\n'
+            ).encode("ascii")
+            + b"\xff\xfe\n"
+            + (f"--{boundary}--\n").encode("ascii")
+        )
+        request = MockRequest(
+            "http://localhost",
+            "post",
+            "/test",
+            content_type=f"multipart/form-data; boundary={boundary}",
+            data=data,
+        )
+
+        result = spec.unmarshal_request(request)
+
+        assert result.errors == []
+        assert result.body == {"file": b"\xff\xfe"}
+
+    @pytest.mark.xfail(
+        reason=(
+            "Form-media composed-schema decoding drops fields matched only "
+            "through typed additionalProperties"
+        ),
+        strict=True,
+    )
+    def test_request_body_urlencoded_oneof_typed_additional_properties_keeps_matching_fields(
+        self,
+    ):
+        from openapi_core import OpenAPI
+
+        spec = OpenAPI.from_dict(
+            {
+                "openapi": "3.1.0",
+                "info": {"version": "0", "title": "test"},
+                "paths": {
+                    "/test": {
+                        "post": {
+                            "requestBody": {
+                                "required": True,
+                                "content": {
+                                    "application/x-www-form-urlencoded": {
+                                        "schema": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                        "type": "integer"
+                                                    },
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "name": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["name"],
+                                                    "additionalProperties": False,
+                                                },
+                                            ]
+                                        }
+                                    }
+                                },
+                            },
+                            "responses": {"200": {"description": ""}},
+                        }
+                    }
+                },
+            }
+        )
+        request = MockRequest(
+            "http://localhost",
+            "post",
+            "/test",
+            content_type="application/x-www-form-urlencoded",
+            data=b"x=1",
+        )
+
+        result = spec.unmarshal_request(request)
+
+        assert result.errors == []
+        assert result.body == {"x": 1}
+
+    def test_request_body_multipart_oneof_rejects_mixed_fields(self):
+        from openapi_core import OpenAPI
+
+        boundary = "testboundary"
+        spec = OpenAPI.from_dict(
+            {
+                "openapi": "3.1.0",
+                "info": {"version": "0", "title": "test"},
+                "paths": {
+                    "/test": {
+                        "post": {
+                            "requestBody": {
+                                "required": True,
+                                "content": {
+                                    "multipart/form-data": {
+                                        "schema": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "label": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["label"],
+                                                    "additionalProperties": False,
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "file": {
+                                                            "type": "string",
+                                                            "format": "binary",
+                                                        }
+                                                    },
+                                                    "required": ["file"],
+                                                    "additionalProperties": False,
+                                                },
+                                            ]
+                                        }
+                                    }
+                                },
+                            },
+                            "responses": {"200": {"description": ""}},
+                        }
+                    }
+                },
+            }
+        )
+        data = (
+            (
+                f"--{boundary}\n"
+                'Content-Disposition: form-data; name="label"\n\n'
+                "report\n"
+                f"--{boundary}\n"
+                "Content-Type: application/octet-stream\n"
+                "MIME-Version: 1.0\n"
+                'Content-Disposition: form-data; name="file"\n\n'
+            ).encode("ascii")
+            + b"\xff\xfe\n"
+            + (f"--{boundary}--\n").encode("ascii")
+        )
+        request = MockRequest(
+            "http://localhost",
+            "post",
+            "/test",
+            content_type=f"multipart/form-data; boundary={boundary}",
+            data=data,
+        )
+
+        result = spec.unmarshal_request(request)
+
+        assert len(result.errors) == 1
+        assert type(result.errors[0]) == InvalidRequestBody
+        assert result.body is None
+
+    def test_request_body_multipart_oneof_falls_through_decode_errors(self):
+        from openapi_core import OpenAPI
+
+        boundary = "testboundary"
+        spec = OpenAPI.from_dict(
+            {
+                "openapi": "3.1.0",
+                "info": {"version": "0", "title": "test"},
+                "paths": {
+                    "/test": {
+                        "post": {
+                            "requestBody": {
+                                "required": True,
+                                "content": {
+                                    "multipart/form-data": {
+                                        "schema": {
+                                            "oneOf": [
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "value": {
+                                                            "type": "integer"
+                                                        }
+                                                    },
+                                                    "required": ["value"],
+                                                },
+                                                {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "value": {
+                                                            "type": "string"
+                                                        }
+                                                    },
+                                                    "required": ["value"],
+                                                },
+                                            ]
+                                        }
+                                    }
+                                },
+                            },
+                            "responses": {"200": {"description": ""}},
+                        }
+                    }
+                },
+            }
+        )
+        data = (
+            f"--{boundary}\n"
+            'Content-Disposition: form-data; name="value"\n\n'
+            "abc\n"
+            f"--{boundary}--\n"
+        ).encode("ascii")
+        request = MockRequest(
+            "http://localhost",
+            "post",
+            "/test",
+            content_type=f"multipart/form-data; boundary={boundary}",
+            data=data,
+        )
+
+        result = spec.unmarshal_request(request)
+
+        assert result.errors == []
+        assert result.body == {"value": "abc"}

--- a/tests/integration/unmarshalling/test_request_unmarshaller.py
+++ b/tests/integration/unmarshalling/test_request_unmarshaller.py
@@ -582,13 +582,6 @@ class TestRequestUnmarshaller:
         assert result.errors == []
         assert result.body == {"a": 1, "b": True}
 
-    @pytest.mark.xfail(
-        reason=(
-            "Form-media oneOf behavior is greedy and selects the first "
-            "matching branch instead of enforcing oneOf exclusivity"
-        ),
-        strict=True,
-    )
     def test_request_body_urlencoded_oneof_rejects_ambiguous_matches(self):
         from openapi_core import OpenAPI
 

--- a/tests/unit/deserializing/test_media_types_deserializers.py
+++ b/tests/unit/deserializing/test_media_types_deserializers.py
@@ -657,12 +657,70 @@ class TestMediaTypeDeserializer:
 
         assert result == {"tags": []}
 
-    @pytest.mark.xfail(
-        reason=(
-            "multipart composed-schema branch selection is not binary-aware"
-        ),
-        strict=True,
-    )
+    def test_urlencoded_oneof_does_not_match_defaults_only(
+        self, spec, deserializer_factory
+    ):
+        mimetype = "application/x-www-form-urlencoded"
+        schema_dict = {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": ["x"],
+                    "properties": {
+                        "x": {"type": "integer", "default": 1},
+                    },
+                },
+                {
+                    "type": "object",
+                    "required": ["y"],
+                    "properties": {
+                        "y": {"type": "string"},
+                    },
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        deserializer = deserializer_factory(
+            mimetype, schema=schema, schema_validator=schema_validator
+        )
+
+        result = deserializer.deserialize(b"")
+
+        assert result == {}
+
+    def test_urlencoded_allof_typeless_fragments(
+        self, spec, deserializer_factory
+    ):
+        mimetype = "application/x-www-form-urlencoded"
+        schema_dict = {
+            "type": "object",
+            "allOf": [
+                {
+                    "properties": {
+                        "a": {"type": "integer"},
+                    },
+                },
+                {
+                    "properties": {
+                        "b": {"type": "boolean"},
+                    },
+                },
+            ],
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        deserializer = deserializer_factory(
+            mimetype, schema=schema, schema_validator=schema_validator
+        )
+
+        result = deserializer.deserialize(b"a=1&b=true")
+
+        assert result == {
+            "a": 1,
+            "b": True,
+        }
+
     def test_multipart_oneof_binary_field(self, spec, deserializer_factory):
         mimetype = "multipart/form-data"
         schema_dict = {
@@ -707,12 +765,54 @@ class TestMediaTypeDeserializer:
             "file": b"\xff\xfe",
         }
 
-    @pytest.mark.xfail(
-        reason=(
-            "multipart composed-schema branch selection is not binary-aware"
-        ),
-        strict=True,
-    )
+    def test_multipart_oneof_binary_field_over_plain_string_field(
+        self, spec, deserializer_factory
+    ):
+        mimetype = "multipart/form-data"
+        schema_dict = {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "file": {"type": "string", "format": "binary"},
+                    },
+                    "required": ["file"],
+                    "additionalProperties": False,
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "file": {"type": "string"},
+                    },
+                    "required": ["file"],
+                    "additionalProperties": False,
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        parameters = {
+            "boundary": "===============2872712225071193122==",
+        }
+        deserializer = deserializer_factory(
+            mimetype,
+            schema=schema,
+            schema_validator=schema_validator,
+            parameters=parameters,
+        )
+        value = (
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: application/octet-stream\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="file"\n\n\xff\xfe\n'
+            b"--===============2872712225071193122==--\n"
+        )
+
+        result = deserializer.deserialize(value)
+
+        assert result == {
+            "file": b"\xff\xfe",
+        }
+
     def test_multipart_anyof_binary_field(self, spec, deserializer_factory):
         mimetype = "multipart/form-data"
         schema_dict = {
@@ -753,4 +853,182 @@ class TestMediaTypeDeserializer:
 
         assert result == {
             "file": b"\xff\xfe",
+        }
+
+    def test_multipart_anyof_binary_field_over_plain_string_field(
+        self, spec, deserializer_factory
+    ):
+        mimetype = "multipart/form-data"
+        schema_dict = {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "file": {"type": "string", "format": "binary"},
+                    },
+                    "required": ["file"],
+                    "additionalProperties": False,
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "file": {"type": "string"},
+                    },
+                    "required": ["file"],
+                    "additionalProperties": False,
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        parameters = {
+            "boundary": "===============2872712225071193122==",
+        }
+        deserializer = deserializer_factory(
+            mimetype,
+            schema=schema,
+            schema_validator=schema_validator,
+            parameters=parameters,
+        )
+        value = (
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: application/octet-stream\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="file"\n\n\xff\xfe\n'
+            b"--===============2872712225071193122==--\n"
+        )
+
+        result = deserializer.deserialize(value)
+
+        assert result == {
+            "file": b"\xff\xfe",
+        }
+
+    @pytest.mark.xfail(
+        reason=(
+            "Form-media composed-schema decoding drops fields matched only "
+            "through typed additionalProperties"
+        ),
+        strict=True,
+    )
+    def test_urlencoded_oneof_typed_additional_properties_keeps_matching_fields(
+        self, spec, deserializer_factory
+    ):
+        mimetype = "application/x-www-form-urlencoded"
+        schema_dict = {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": {"type": "integer"},
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                    },
+                    "required": ["name"],
+                    "additionalProperties": False,
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        deserializer = deserializer_factory(
+            mimetype, schema=schema, schema_validator=schema_validator
+        )
+
+        result = deserializer.deserialize(b"x=1")
+
+        assert result == {"x": 1}
+
+    def test_multipart_oneof_does_not_match_mixed_fields(
+        self, spec, deserializer_factory
+    ):
+        mimetype = "multipart/form-data"
+        schema_dict = {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "label": {"type": "string"},
+                    },
+                    "required": ["label"],
+                    "additionalProperties": False,
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "file": {"type": "string", "format": "binary"},
+                    },
+                    "required": ["file"],
+                    "additionalProperties": False,
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        parameters = {
+            "boundary": "===============2872712225071193122==",
+        }
+        deserializer = deserializer_factory(
+            mimetype,
+            schema=schema,
+            schema_validator=schema_validator,
+            parameters=parameters,
+        )
+        value = (
+            b"--===============2872712225071193122==\n"
+            b'Content-Disposition: form-data; name="label"\n\nreport\n'
+            b"--===============2872712225071193122==\n"
+            b"Content-Type: application/octet-stream\nMIME-Version: 1.0\n"
+            b'Content-Disposition: form-data; name="file"\n\n\xff\xfe\n'
+            b"--===============2872712225071193122==--\n"
+        )
+
+        result = deserializer.deserialize(value)
+
+        assert result == {}
+
+    def test_multipart_oneof_falls_through_decode_errors(
+        self, spec, deserializer_factory
+    ):
+        mimetype = "multipart/form-data"
+        schema_dict = {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "integer"},
+                    },
+                    "required": ["value"],
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string"},
+                    },
+                    "required": ["value"],
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        parameters = {
+            "boundary": "===============2872712225071193122==",
+        }
+        deserializer = deserializer_factory(
+            mimetype,
+            schema=schema,
+            schema_validator=schema_validator,
+            parameters=parameters,
+        )
+        value = (
+            b"--===============2872712225071193122==\n"
+            b'Content-Disposition: form-data; name="value"\n\nabc\n'
+            b"--===============2872712225071193122==--\n"
+        )
+
+        result = deserializer.deserialize(value)
+
+        assert result == {
+            "value": "abc",
         }

--- a/tests/unit/deserializing/test_media_types_deserializers.py
+++ b/tests/unit/deserializing/test_media_types_deserializers.py
@@ -721,6 +721,38 @@ class TestMediaTypeDeserializer:
             "b": True,
         }
 
+    def test_urlencoded_oneof_does_not_match_ambiguous_fields(
+        self, spec, deserializer_factory
+    ):
+        mimetype = "application/x-www-form-urlencoded"
+        schema_dict = {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": ["a"],
+                    "properties": {
+                        "a": {"type": "string"},
+                    },
+                },
+                {
+                    "type": "object",
+                    "required": ["b"],
+                    "properties": {
+                        "b": {"type": "string"},
+                    },
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(spec, schema)
+        deserializer = deserializer_factory(
+            mimetype, schema=schema, schema_validator=schema_validator
+        )
+
+        result = deserializer.deserialize(b"a=x&b=y")
+
+        assert result == {}
+
     def test_multipart_oneof_binary_field(self, spec, deserializer_factory):
         mimetype = "multipart/form-data"
         schema_dict = {


### PR DESCRIPTION
- Fix composed form-media schema matching for `multipart/form-data` and `application/x-www-form-urlencoded`.
- Prevent `oneOf` branch selection from being influenced by defaults or by dropping extra submitted fields during validation.
- Handle typeless `allOf` object fragments correctly and keep binary/byte validation working for multi-type schemas like `["string", "null"]`.
- Preserve binary multipart field values when overlapping `oneOf`/`anyOf` branches describe the same field as both `string` and `string` with `binary`/`byte` formats.