### PR TITLE
Upgrade jsonschema-path 0.5 schema-validator 0.9 spec-validator 0.9

### DIFF
--- a/openapi_core/templating/paths/finders.py
+++ b/openapi_core/templating/paths/finders.py
@@ -18,6 +18,8 @@ from openapi_core.templating.paths.protocols import OperationsIterator
 from openapi_core.templating.paths.protocols import PathsIterator
 from openapi_core.templating.paths.protocols import ServersIterator
 
+DEFAULT_SERVER = SchemaPath.from_dict({"url": "/"})
+
 
 class BasePathFinder:
     paths_iterator: PathsIterator = NotImplemented
@@ -63,7 +65,7 @@ class BasePathFinder:
 class APICallPathFinder(BasePathFinder):
     paths_iterator: PathsIterator = TemplatePathsIterator("paths")
     operations_iterator: OperationsIterator = SimpleOperationsIterator()
-    servers_iterator: ServersIterator = TemplateServersIterator()
+    servers_iterator: ServersIterator = TemplateServersIterator(DEFAULT_SERVER)
 
 
 class WebhookPathFinder(APICallPathFinder):

--- a/openapi_core/templating/paths/iterators.py
+++ b/openapi_core/templating/paths/iterators.py
@@ -122,6 +122,9 @@ class SimpleServersIterator:
 
 
 class TemplateServersIterator:
+    def __init__(self, default_server: SchemaPath):
+        self.default_server = default_server
+
     def __call__(
         self,
         name: str,
@@ -136,7 +139,7 @@ class TemplateServersIterator:
                 or spec.get("servers", None)
             )
             if not servers:
-                servers = [SchemaPath.from_dict({"url": "/"})]
+                servers = [self.default_server]
             for server in servers:
                 server_url_pattern = name.rsplit(path_result.resolved, 1)[0]
                 server_url = server["url"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1610,40 +1610,41 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jsonschema"
-version = "4.24.1"
+version = "4.26.0"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "jsonschema-4.24.1-py3-none-any.whl", hash = "sha256:6b916866aa0b61437785f1277aa2cbd63512e8d4b47151072ef13292049b4627"},
-    {file = "jsonschema-4.24.1.tar.gz", hash = "sha256:fe45a130cc7f67cd0d67640b4e7e3e2e666919462ae355eda238296eafeb4b5d"},
+    {file = "jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"},
+    {file = "jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"},
 ]
 
 [package.dependencies]
 attrs = ">=22.2.0"
 jsonschema-specifications = ">=2023.3.6"
 referencing = ">=0.28.4"
-rpds-py = ">=0.7.1"
+rpds-py = ">=0.25.0"
 
 [package.extras]
 format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
-format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=24.6.0)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "rfc3987-syntax (>=1.1.0)", "uri-template", "webcolors (>=24.6.0)"]
 
 [[package]]
 name = "jsonschema-path"
-version = "0.4.6"
+version = "0.5.0"
 description = "JSONSchema Spec with object-oriented paths"
 optional = false
 python-versions = "<4.0.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "jsonschema_path-0.4.6-py3-none-any.whl", hash = "sha256:451354b5311fa955c3144e6e4e255388c751c0121c5570ec5bb9291dd42d08c9"},
-    {file = "jsonschema_path-0.4.6.tar.gz", hash = "sha256:c89eb635f4d497c9ac328eeff359c489755838806a7d033510a692e9576f5c4b"},
+    {file = "jsonschema_path-0.5.0-py3-none-any.whl", hash = "sha256:2790a070bc7abb08ea3dbe4d340ece4efadf639223001f020c7503229ba068e2"},
+    {file = "jsonschema_path-0.5.0.tar.gz", hash = "sha256:493b156ba895c97602655b620a8456caa2ce08c1aa389f5a7addec065e6e855c"},
 ]
 
 [package.dependencies]
-pathable = ">=0.5.0,<0.6.0"
+attrs = ">=22.2.0"
+pathable = ">=0.6.0,<0.7.0"
 PyYAML = ">=5.1"
 referencing = "<0.38.0"
 
@@ -2417,14 +2418,14 @@ setuptools = "*"
 
 [[package]]
 name = "openapi-schema-validator"
-version = "0.8.1"
+version = "0.9.0"
 description = "OpenAPI schema validation for Python"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main"]
 files = [
-    {file = "openapi_schema_validator-0.8.1-py3-none-any.whl", hash = "sha256:0f5859794c5bfa433d478dc5ac5e5768d50adc56b14380c8a6fd3a8113e89c9b"},
-    {file = "openapi_schema_validator-0.8.1.tar.gz", hash = "sha256:4c57266ce8cbfa37bb4eb4d62cdb7d19356c3a468e3535743c4562863e1790da"},
+    {file = "openapi_schema_validator-0.9.0-py3-none-any.whl", hash = "sha256:faa3bbe7c3aa8ca2087ad83f709dc3b7d920283153a570c03e24ea182558aa25"},
+    {file = "openapi_schema_validator-0.9.0.tar.gz", hash = "sha256:b72db64315b89d21834cd3ffef37e3e6893bc876327be2d366e8424b1029afd3"},
 ]
 
 [package.dependencies]
@@ -2440,21 +2441,21 @@ ecma-regex = ["regress (>=2025.10.1)"]
 
 [[package]]
 name = "openapi-spec-validator"
-version = "0.8.4"
+version = "0.9.0"
 description = "OpenAPI 2.0 (aka Swagger) and OpenAPI 3 spec validator"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "openapi_spec_validator-0.8.4-py3-none-any.whl", hash = "sha256:cf905117063d7c4d495c8a5a167a1f2a8006da6ffa8ba234a7ed0d0f11454d51"},
-    {file = "openapi_spec_validator-0.8.4.tar.gz", hash = "sha256:8bb324b9b08b9b368b1359dec14610c60a8f3a3dd63237184eb04456d4546f49"},
+    {file = "openapi_spec_validator-0.9.0-py3-none-any.whl", hash = "sha256:222fecffc7714f6d0a6ad62c0e4b66cc2b7dbfafb7b93acfc6c308abbdb51af8"},
+    {file = "openapi_spec_validator-0.9.0.tar.gz", hash = "sha256:6d648cff6490ebb799dcfe273792f2941c050158854c721f086599d845da78b8"},
 ]
 
 [package.dependencies]
-jsonschema = ">=4.24.0,<4.25.0"
-jsonschema-path = ">=0.4.3,<0.5.0"
+jsonschema = ">=4.26.0,<5.0.0"
+jsonschema-path = ">=0.5.0,<0.6.0"
 lazy-object-proxy = ">=1.7.1,<2.0"
-openapi-schema-validator = ">=0.7.3,<0.9.0"
+openapi-schema-validator = ">=0.9.0,<0.10.0"
 pydantic = ">=2.0.0,<3.0.0"
 pydantic-settings = ">=2.0.0,<3.0.0"
 
@@ -2504,14 +2505,14 @@ testing = ["docopt", "pytest"]
 
 [[package]]
 name = "pathable"
-version = "0.5.0"
+version = "0.6.0"
 description = "Object-oriented paths"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6"},
-    {file = "pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1"},
+    {file = "pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566"},
+    {file = "pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58"},
 ]
 
 [[package]]
@@ -4201,4 +4202,4 @@ werkzeug = []
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10.0"
-content-hash = "4e39b1c2b0269c546429298dc38276f0b3eee47c214ffa041b23dce230b9ab13"
+content-hash = "9882d04922821ba554167b79a1f58717fd0bfbe76ca60ff2604677ac43496421"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,11 +67,11 @@ aiohttp = {version = ">=3.0", optional = true}
 starlette = {version = ">=0.40.0,<1.1.0", optional = true}
 isodate = "*"
 more-itertools = "*"
-openapi-schema-validator = ">=0.7.0,<0.9.0"
-openapi-spec-validator = "^0.8.0"
+openapi-schema-validator = "^0.9.0"
+openapi-spec-validator = "^0.9.0"
 requests = {version = "*", optional = true}
 werkzeug = ">=2.1.0"
-jsonschema-path = "^0.4.5"
+jsonschema-path = "^0.5.0"
 jsonschema = "^4.23.0"
 multidict = {version = "^6.0.4", optional = true}
 aioitertools = {version = ">=0.11,<0.14", optional = true}

--- a/tests/unit/templating/test_paths_finders.py
+++ b/tests/unit/templating/test_paths_finders.py
@@ -6,6 +6,7 @@ from openapi_core.templating.paths.exceptions import OperationNotFound
 from openapi_core.templating.paths.exceptions import PathNotFound
 from openapi_core.templating.paths.exceptions import PathsNotFound
 from openapi_core.templating.paths.exceptions import ServerNotFound
+from openapi_core.templating.paths.finders import DEFAULT_SERVER
 from openapi_core.templating.paths.finders import APICallPathFinder
 
 
@@ -195,13 +196,12 @@ class BaseTestDefaultServer:
 
         path = spec / "paths" / self.path_name
         operation = spec / "paths" / self.path_name / method
-        server = SchemaPath.from_dict({"url": "/"})
         path_result = TemplateResult(self.path_name, {})
         server_result = TemplateResult("/", {})
         assert result == (
             path,
             operation,
-            server,
+            DEFAULT_SERVER,
             path_result,
             server_result,
         )


### PR DESCRIPTION
`SchemaPath` instances are equal if they have the same parts and point to the same `SchemaAccessor`. `SchemaAccessor` identity is per-resource-handle: same wrapped dict (by reference), same base_uri, and same internal resolver instance.

## Backward incompatibilities
* Validation results may change for specifications that previously relied on discriminator-based narrowing or on discriminator mapping resolution errors during validation.