### PR TITLE
Treat binary string schemas as opaque bytes

### DIFF
--- a/openapi_core/deserializing/media_types/deserializers.py
+++ b/openapi_core/deserializing/media_types/deserializers.py
@@ -18,6 +18,7 @@ from openapi_core.deserializing.media_types.exceptions import (
 from openapi_core.deserializing.styles.factories import (
     StyleDeserializersFactory,
 )
+from openapi_core.schema.binary import is_binary_schema
 from openapi_core.schema.encodings import get_content_type
 from openapi_core.schema.parameters import get_style_and_explode
 from openapi_core.schema.protocols import SuportsGetAll
@@ -294,12 +295,15 @@ class MediaTypeDeserializer:
         prop_schema: SchemaPath,
     ) -> bool:
         schema_type = (prop_schema / "type").read_str(None)
-        schema_format = (prop_schema / "format").read_str(None)
 
         if schema_type in ["integer", "number", "boolean"]:
             return True
 
-        return schema_type == "string" and schema_format != "binary"
+        # A string part is decoded to text unless it is an opaque binary
+        # payload. Routing through the canonical predicate means OAS 3.1
+        # ``contentMediaType`` binary parts are left as raw bytes too --
+        # keying on ``format != "binary"`` alone would wrongly decode them.
+        return schema_type == "string" and not is_binary_schema(prop_schema)
 
     def decode_multipart_form_value(self, value: bytes) -> str:
         try:

--- a/openapi_core/schema/binary.py
+++ b/openapi_core/schema/binary.py
@@ -1,0 +1,102 @@
+"""Canonical detection of "binary" (opaque, non-text) string schemas.
+
+OpenAPI expresses "this string carries raw, opaque bytes" in two
+different ways depending on the version:
+
+* OpenAPI 3.0 uses ``type: string`` together with ``format: binary``
+  (raw octets) or ``format: byte`` (base64-encoded *text*).
+* OpenAPI 3.1+ aligns with JSON Schema 2020-12, where ``binary``/``byte``
+  are no longer defined formats. Raw bytes are described with
+  ``contentMediaType`` (e.g. ``application/octet-stream``) and base64
+  payloads with ``contentEncoding: base64``. Per JSON Schema Validation
+  §8 these content keywords are *annotations, not assertions*, so a
+  conforming validator does not reject a value for carrying raw bytes.
+
+This module is the single source of truth for that distinction so the
+deserializer, validator, unmarshaller and encoding helpers all agree on
+what counts as binary. ``byte``/``base64`` are deliberately *excluded*
+from the binary set: those are text (base64) and must keep flowing
+through the normal string/text code paths.
+
+Predicates accept either a ``jsonschema_path.SchemaPath`` (used through
+most of openapi-core) or a plain ``Mapping`` (the shape jsonschema hands
+a custom keyword validator).
+"""
+
+from typing import Any
+from typing import Mapping
+from typing import Optional
+from typing import Union
+
+from jsonschema_path import SchemaPath
+
+# ``format`` values denoting base64-encoded *text* (NOT opaque bytes).
+# ``base64`` is an accepted alternate spelling for ``byte``.
+_BASE64_FORMATS = frozenset({"byte", "base64"})
+
+# JSON Schema 2020-12 ``contentEncoding`` values denoting base64 text.
+_BASE64_ENCODINGS = frozenset({"base64", "base64url"})
+
+SchemaLike = Union[SchemaPath, Mapping[str, Any]]
+
+
+def _read_str(schema: SchemaLike, key: str) -> Optional[str]:
+    if isinstance(schema, SchemaPath):
+        return (schema / key).read_str(None)
+    value = schema.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _read_type(schema: SchemaLike) -> Union[None, str, list[str]]:
+    if isinstance(schema, SchemaPath):
+        return (schema / "type").read_str_or_list(None)
+    value = schema.get("type")
+    if value is None or isinstance(value, (str, list)):
+        return value
+    return None
+
+
+def type_allows_string(schema: SchemaLike) -> bool:
+    """True if a ``string`` instance is permitted at this schema node.
+
+    A missing ``type`` is treated as permissive (OAS 3.1 / JSON Schema
+    leaves any value allowed), so the binary/content keywords remain
+    authoritative.
+    """
+    types = _read_type(schema)
+    if types is None:
+        return True
+    if isinstance(types, str):
+        return types == "string"
+    return "string" in types
+
+
+def is_base64_schema(schema: SchemaLike) -> bool:
+    """True when the schema describes base64-encoded *text*."""
+    if _read_str(schema, "format") in _BASE64_FORMATS:
+        return True
+    return _read_str(schema, "contentEncoding") in _BASE64_ENCODINGS
+
+
+def is_binary_schema(schema: SchemaLike) -> bool:
+    """True when the schema describes an opaque, non-text byte payload.
+
+    Covers OAS 3.0 ``format: binary`` and OAS 3.1
+    ``contentMediaType`` of a non-``text/*`` media type. Base64 text
+    (``format: byte``/``base64`` or ``contentEncoding``) is explicitly
+    excluded -- it stays on the normal text path.
+    """
+    if not isinstance(schema, (SchemaPath, Mapping)):
+        return False
+    if not type_allows_string(schema):
+        return False
+    if is_base64_schema(schema):
+        return False
+    if _read_str(schema, "format") == "binary":
+        return True
+    content_media_type = _read_str(schema, "contentMediaType")
+    if content_media_type is not None and not content_media_type.startswith(
+        "text/"
+    ):
+        return True
+    return False

--- a/openapi_core/schema/encodings.py
+++ b/openapi_core/schema/encodings.py
@@ -3,6 +3,8 @@ from typing import cast
 
 from jsonschema_path import SchemaPath
 
+from openapi_core.schema.binary import is_binary_schema
+
 
 def get_content_type(
     prop_schema: SchemaPath, encoding: Optional[SchemaPath]
@@ -26,8 +28,11 @@ def get_default_content_type(
     if prop_type is None:
         return "text/plain" if encoding else "application/octet-stream"
 
-    prop_format = (prop_schema / "format").read_str(None)
-    if prop_type == "string" and prop_format in ["binary", "base64"]:
+    if prop_type == "string" and is_binary_schema(prop_schema):
+        # Opaque binary (OAS 3.0 ``format: binary`` or OAS 3.1
+        # ``contentMediaType``) defaults to octet-stream. base64 text
+        # (``byte``/``base64``/``contentEncoding``) is NOT binary and
+        # falls through to ``text/plain`` below.
         return "application/octet-stream"
 
     if prop_type == "object":

--- a/openapi_core/templating/media_types/finders.py
+++ b/openapi_core/templating/media_types/finders.py
@@ -61,7 +61,10 @@ class MediaTypeFinder:
                 except "charset" which is case-insensitive
                 https://www.rfc-editor.org/rfc/rfc2046#section-4.1.2
         """
-        name, value = parameter.split("=")
+        # Split on the first "=" only: a parameter value may itself
+        # contain "=" (e.g. a multipart ``boundary`` like
+        # ``===============123==``), which RFC 9110 permits.
+        name, value = parameter.split("=", 1)
         name = name.lower().lstrip()
         # remove surrounding quotes from value
         value = re.sub('^"(.*)"$', r"\1", value, count=1)

--- a/openapi_core/validation/schemas/_validators.py
+++ b/openapi_core/validation/schemas/_validators.py
@@ -1,6 +1,8 @@
 from typing import Any
+from typing import Callable
 from typing import Iterator
 from typing import Mapping
+from typing import Optional
 from typing import cast
 
 from jsonschema._utils import extras_msg
@@ -8,6 +10,10 @@ from jsonschema._utils import find_additional_properties
 from jsonschema.exceptions import ValidationError
 from jsonschema.protocols import Validator
 from jsonschema.validators import extend
+
+from openapi_core.schema.binary import is_binary_schema
+
+_KeywordValidator = Callable[[Any, Any, Any, Mapping[str, Any]], Iterator[Any]]
 
 
 def build_forbid_unspecified_additional_properties_validator(
@@ -81,6 +87,82 @@ def iter_missing_additional_properties_errors(
     if extras:
         error = "Additional properties are not allowed (%s %s unexpected)"
         yield ValidationError(error % extras_msg(extras))
+
+
+def build_binary_aware_validator(
+    validator_class: type[Validator],
+) -> type[Validator]:
+    """Extend ``validator_class`` so raw ``bytes`` validate against
+    "binary" string schemas.
+
+    OpenAPI lets a ``bytes`` payload flow through a ``type: string``
+    schema whose ``format``/``contentMediaType`` marks it as opaque
+    binary (file uploads, ``application/octet-stream`` bodies). Plain
+    jsonschema rejects ``bytes`` as a non-``string`` and then crashes or
+    misfires on ``pattern``/length/``enum``/``format`` keywords.
+
+    We treat the byte payload as *opaque* -- consistent with JSON Schema
+    2020-12 where ``contentMediaType``/``contentEncoding`` are
+    annotations, not assertions. The ``type`` keyword accepts the bytes,
+    and the string-only assertion keywords are skipped *only* at a
+    binary node holding bytes. Every other instance/keyword combination
+    is delegated unchanged to the wrapped validator, so behaviour for
+    ordinary strings (including the invariant that ``bytes`` is still
+    rejected against a plain ``type: string``) is preserved. Because the
+    binary branch now validates, jsonschema's own ``oneOf``/``anyOf``/
+    ``allOf`` selection picks it without any parallel value walk.
+    """
+    type_validator = validator_class.VALIDATORS.get("type")
+
+    def _is_opaque_binary(instance: Any, schema: Mapping[str, Any]) -> bool:
+        return isinstance(instance, bytes) and is_binary_schema(schema)
+
+    def binary_aware_type(
+        validator: Any,
+        data_type: Any,
+        instance: Any,
+        schema: Mapping[str, Any],
+    ) -> Iterator[Any]:
+        if _is_opaque_binary(instance, schema):
+            return
+        if type_validator is not None:
+            yield from type_validator(validator, data_type, instance, schema)
+
+    def _skip_binary(
+        original: Optional[_KeywordValidator],
+    ) -> _KeywordValidator:
+        def keyword(
+            validator: Any,
+            keyword_value: Any,
+            instance: Any,
+            schema: Mapping[str, Any],
+        ) -> Iterator[Any]:
+            if _is_opaque_binary(instance, schema):
+                return
+            if original is not None:
+                yield from original(validator, keyword_value, instance, schema)
+
+        return keyword
+
+    validators: dict[str, _KeywordValidator] = {"type": binary_aware_type}
+    # String-only assertion keywords: harmless to skip on an opaque byte
+    # payload, and ``pattern`` in particular raises ``TypeError`` when
+    # applied to ``bytes``.
+    for keyword_name in (
+        "pattern",
+        "minLength",
+        "maxLength",
+        "enum",
+        "format",
+    ):
+        validators[keyword_name] = _skip_binary(
+            validator_class.VALIDATORS.get(keyword_name)
+        )
+
+    return cast(
+        type[Validator],
+        extend(validator_class, validators=validators),
+    )
 
 
 def build_enforce_properties_required_validator(

--- a/openapi_core/validation/schemas/factories.py
+++ b/openapi_core/validation/schemas/factories.py
@@ -10,6 +10,9 @@ from jsonschema.validators import validator_for
 from jsonschema_path import SchemaPath
 
 from openapi_core.validation.schemas._validators import (
+    build_binary_aware_validator,
+)
+from openapi_core.validation.schemas._validators import (
     build_enforce_properties_required_validator,
 )
 from openapi_core.validation.schemas._validators import (
@@ -74,6 +77,11 @@ class SchemaValidatorsFactory:
         enforce_properties_required: bool = False,
     ) -> SchemaValidator:
         validator_cls: type[Validator] = self.get_validator_cls(spec, schema)
+        # Always binary-aware: a ``bytes`` payload must validate against a
+        # binary string schema (file uploads, octet-stream bodies). Applied
+        # first so the conditional extensions below chain their own ``type``
+        # override on top of the binary-aware one.
+        validator_cls = build_binary_aware_validator(validator_cls)
         if enforce_properties_required:
             validator_cls = build_enforce_properties_required_validator(
                 validator_cls

--- a/openapi_core/validation/schemas/validators.py
+++ b/openapi_core/validation/schemas/validators.py
@@ -11,6 +11,7 @@ from jsonschema.exceptions import FormatError
 from jsonschema.protocols import Validator
 from jsonschema_path import SchemaPath
 
+from openapi_core.schema.binary import is_binary_schema
 from openapi_core.validation.schemas.datatypes import (
     _EMPTY_STATE_TUPLE as _EMPTY_STATES_TUPLE,
 )
@@ -272,6 +273,14 @@ class SchemaValidator:
             schema_types = sorted(self.validator.TYPE_CHECKER._type_checkers)
         assert isinstance(schema_types, list)
         for schema_type in schema_types:
+            if schema_type == "string" and isinstance(value, bytes):
+                # OpenAPI lets raw ``bytes`` satisfy a binary string
+                # schema. jsonschema's type checker doesn't know that
+                # convention, so resolve it here to keep primitive-type
+                # detection (and downstream format discovery) consistent
+                # with the binary-aware validator.
+                if is_binary_schema(self.schema):
+                    return "string"
             result = self.type_validator(value, type_override=schema_type)
             if not result:
                 continue

--- a/tests/integration/unmarshalling/test_request_unmarshaller.py
+++ b/tests/integration/unmarshalling/test_request_unmarshaller.py
@@ -469,12 +469,6 @@ class TestRequestUnmarshaller:
         assert result.errors == []
         assert result.body == {"tags": []}
 
-    @pytest.mark.xfail(
-        reason=(
-            "multipart composed-schema branch selection is not binary-aware"
-        ),
-        strict=True,
-    )
     def test_request_body_multipart_oneof_binary_field(self):
         from openapi_core import OpenAPI
 

--- a/tests/unit/deserializing/test_media_types_deserializers.py
+++ b/tests/unit/deserializing/test_media_types_deserializers.py
@@ -657,12 +657,6 @@ class TestMediaTypeDeserializer:
 
         assert result == {"tags": []}
 
-    @pytest.mark.xfail(
-        reason=(
-            "multipart composed-schema branch selection is not binary-aware"
-        ),
-        strict=True,
-    )
     def test_multipart_oneof_binary_field(self, spec, deserializer_factory):
         mimetype = "multipart/form-data"
         schema_dict = {
@@ -757,12 +751,6 @@ class TestMediaTypeDeserializer:
             "fieldA": "value",
         }
 
-    @pytest.mark.xfail(
-        reason=(
-            "multipart composed-schema branch selection is not binary-aware"
-        ),
-        strict=True,
-    )
     def test_multipart_anyof_binary_field(self, spec, deserializer_factory):
         mimetype = "multipart/form-data"
         schema_dict = {

--- a/tests/unit/schema/test_binary.py
+++ b/tests/unit/schema/test_binary.py
@@ -1,0 +1,71 @@
+import pytest
+from jsonschema_path import SchemaPath
+
+from openapi_core.schema.binary import is_base64_schema
+from openapi_core.schema.binary import is_binary_schema
+
+
+def _path(schema_dict):
+    return SchemaPath.from_dict(schema_dict)
+
+
+class TestIsBinarySchema:
+    @pytest.mark.parametrize(
+        "schema_dict",
+        [
+            # OAS 3.0 raw octets
+            {"type": "string", "format": "binary"},
+            # OAS 3.1 content media type (non-text)
+            {"type": "string", "contentMediaType": "application/octet-stream"},
+            {"type": "string", "contentMediaType": "image/png"},
+            # no declared type -> binary keyword is authoritative
+            {"format": "binary"},
+            # multi-type including string
+            {"type": ["string", "null"], "format": "binary"},
+        ],
+    )
+    def test_binary(self, schema_dict):
+        assert is_binary_schema(_path(schema_dict)) is True
+        # plain-dict form (the shape a jsonschema keyword validator sees)
+        assert is_binary_schema(schema_dict) is True
+
+    @pytest.mark.parametrize(
+        "schema_dict",
+        [
+            # base64 text is NOT binary
+            {"type": "string", "format": "byte"},
+            {"type": "string", "format": "base64"},
+            {"type": "string", "contentEncoding": "base64"},
+            {"type": "string", "contentEncoding": "base64url"},
+            # base64 wins even alongside a non-text contentMediaType
+            {
+                "type": "string",
+                "contentEncoding": "base64",
+                "contentMediaType": "application/octet-stream",
+            },
+            # plain string / other types
+            {"type": "string"},
+            {"type": "integer"},
+            {"type": "object"},
+            # text content media type is not opaque binary
+            {"type": "string", "contentMediaType": "text/plain"},
+            # type explicitly excludes string
+            {"type": "integer", "format": "binary"},
+        ],
+    )
+    def test_not_binary(self, schema_dict):
+        assert is_binary_schema(_path(schema_dict)) is False
+        assert is_binary_schema(schema_dict) is False
+
+    @pytest.mark.parametrize(
+        "schema_dict,expected",
+        [
+            ({"type": "string", "format": "byte"}, True),
+            ({"type": "string", "format": "base64"}, True),
+            ({"type": "string", "contentEncoding": "base64"}, True),
+            ({"type": "string", "format": "binary"}, False),
+            ({"type": "string"}, False),
+        ],
+    )
+    def test_is_base64_schema(self, schema_dict, expected):
+        assert is_base64_schema(_path(schema_dict)) is expected

--- a/tests/unit/validation/test_schema_validators.py
+++ b/tests/unit/validation/test_schema_validators.py
@@ -1,9 +1,13 @@
 import pytest
 from jsonschema_path import SchemaPath
+from openapi_schema_validator import OAS31_BASE_DIALECT_ID
+from openapi_schema_validator import OAS32_BASE_DIALECT_ID
 
 from openapi_core.validation.schemas import (
     oas30_write_schema_validators_factory,
 )
+from openapi_core.validation.schemas import oas31_schema_validators_factory
+from openapi_core.validation.schemas import oas32_schema_validators_factory
 from openapi_core.validation.schemas.exceptions import InvalidSchemaValue
 from openapi_core.validation.schemas.validators import SchemaValidator
 
@@ -498,3 +502,150 @@ class TestSchemaValidateStateRefDedup:
         assert prop_a not in cache
         assert prop_b not in cache
         assert cache[canonical] is True
+
+
+class TestBinaryAwareValidate:
+    """A ``bytes`` payload validates against a binary string schema,
+    while plain (non-binary) string schemas still reject ``bytes``.
+    """
+
+    @pytest.fixture
+    def spec(self):
+        return SchemaPath.from_dict({})
+
+    @pytest.fixture(
+        params=[
+            oas30_write_schema_validators_factory,
+            oas31_schema_validators_factory,
+            oas32_schema_validators_factory,
+        ],
+        ids=["oas30", "oas31", "oas32"],
+    )
+    def factory(self, request):
+        return request.param
+
+    def _validate(self, factory, spec, schema_dict, value):
+        schema = SchemaPath.from_dict(schema_dict)
+        factory.create(spec, schema).validate(value)
+
+    def test_bytes_valid_against_binary_format(self, factory, spec):
+        self._validate(
+            factory, spec, {"type": "string", "format": "binary"}, b"\xff\xfe"
+        )
+
+    def test_bytes_valid_against_content_media_type(self, factory, spec):
+        self._validate(
+            factory,
+            spec,
+            {"type": "string", "contentMediaType": "application/octet-stream"},
+            b"\xff\xfe",
+        )
+
+    def test_bytes_rejected_against_plain_string(self, factory, spec):
+        with pytest.raises(InvalidSchemaValue):
+            self._validate(factory, spec, {"type": "string"}, b"\xff\xfe")
+
+    def test_bytes_rejected_against_byte_base64_format(self, factory, spec):
+        # ``byte`` is base64 *text*, not opaque binary: arbitrary bytes
+        # must not slip through as a string.
+        with pytest.raises(InvalidSchemaValue):
+            self._validate(
+                factory,
+                spec,
+                {"type": "string", "format": "byte"},
+                b"\xff\xfe",
+            )
+
+    def test_bytes_valid_in_oneof_binary_branch(self, factory, spec):
+        schema_dict = {
+            "oneOf": [
+                {"type": "string", "format": "binary"},
+                {"type": "object"},
+            ]
+        }
+        self._validate(factory, spec, schema_dict, b"\xff\xfe")
+
+    def test_bytes_valid_in_anyof_binary_branch(self, factory, spec):
+        schema_dict = {
+            "anyOf": [
+                {"type": "string", "format": "binary"},
+                {"type": "integer"},
+            ]
+        }
+        self._validate(factory, spec, schema_dict, b"\xff\xfe")
+
+    def test_bytes_valid_in_nested_object_property(self, factory, spec):
+        schema_dict = {
+            "type": "object",
+            "properties": {
+                "file": {"type": "string", "format": "binary"},
+            },
+            "required": ["file"],
+        }
+        self._validate(factory, spec, schema_dict, {"file": b"\xff\xfe"})
+
+    def test_string_assertion_keywords_do_not_crash_on_bytes(
+        self, factory, spec
+    ):
+        # ``pattern`` raises TypeError on bytes in plain jsonschema; the
+        # binary node treats the payload as opaque and skips it.
+        schema_dict = {
+            "type": "string",
+            "format": "binary",
+            "pattern": "^a",
+            "minLength": 100,
+            "maxLength": 1,
+        }
+        self._validate(factory, spec, schema_dict, b"\xff\xfe")
+
+    def test_plain_string_still_validates_normally(self, factory, spec):
+        self._validate(factory, spec, {"type": "string"}, "hello")
+
+    def test_input_value_not_mutated(self, factory, spec):
+        schema_dict = {
+            "type": "object",
+            "properties": {
+                "file": {"type": "string", "format": "binary"},
+            },
+        }
+        value = {"file": b"\xff\xfe"}
+        self._validate(factory, spec, schema_dict, value)
+        assert value == {"file": b"\xff\xfe"}
+        assert isinstance(value["file"], bytes)
+
+    @pytest.mark.parametrize(
+        "dialect_factory, dialect_id",
+        [
+            (oas31_schema_validators_factory, OAS31_BASE_DIALECT_ID),
+            (oas32_schema_validators_factory, OAS32_BASE_DIALECT_ID),
+        ],
+        ids=["oas31", "oas32"],
+    )
+    def test_bytes_valid_with_explicit_dialect_in_schema(
+        self, spec, dialect_factory, dialect_id
+    ):
+        # The fixture-driven tests rely on the *default* dialect; here
+        # the schema declares its own dialect via ``$schema`` so the
+        # ``_get_dialect_id`` read-from-schema branch is covered too.
+        schema_dict = {
+            "$schema": dialect_id,
+            "type": "string",
+            "format": "binary",
+        }
+        self._validate(dialect_factory, spec, schema_dict, b"\xff\xfe")
+
+    def test_bytes_on_non_oas_dialect_keeps_binary_handling(self, spec):
+        # Boundary characterization: a schema opting into a *stock* JSON
+        # Schema dialect (not an OAS dialect) still accepts opaque bytes
+        # today, because binary handling wraps whatever validator class
+        # the dialect resolves to. If binary handling is ever delegated
+        # to the per-dialect validator classes, this path needs its own
+        # coverage -- so pin the current behaviour explicitly.
+        schema_dict = {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "format": "binary",
+        }
+        self._validate(
+            oas31_schema_validators_factory, spec, schema_dict, b"\xff\xfe"
+        )


### PR DESCRIPTION
OpenAPI binary string schemas are now treated as opaque bytes.