### PR TITLE
test: add Xquik OpenAPI 3.1 fixture

### DIFF
--- a/tests/integration/data/v3.1/xquik-search.yaml
+++ b/tests/integration/data/v3.1/xquik-search.yaml
@@ -1,0 +1,54 @@
+openapi: 3.1.0
+info:
+  title: Xquik API
+  version: "1.0"
+servers:
+  - url: https://xquik.com
+paths:
+  /api/v1/x/tweets/search:
+    get:
+      operationId: searchTweets
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Search results.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SearchTweetsResponse"
+      security:
+        - apiKey: []
+components:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    SearchTweetsResponse:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/Tweet"
+    Tweet:
+      type: object
+      required:
+        - id
+        - text
+        - authorUsername
+      properties:
+        id:
+          type: string
+        text:
+          type: string
+        authorUsername:
+          type: string

--- a/tests/integration/test_xquik.py
+++ b/tests/integration/test_xquik.py
@@ -1,0 +1,42 @@
+import json
+from pathlib import Path
+
+from openapi_core import OpenAPI
+from openapi_core.testing import MockRequest
+from openapi_core.testing import MockResponse
+
+
+def test_xquik_search_request_and_response():
+    spec_path = Path(__file__).parent / "data/v3.1/xquik-search.yaml"
+    openapi = OpenAPI.from_path(spec_path)
+    request = MockRequest(
+        "https://xquik.com",
+        "get",
+        "/api/v1/x/tweets/search",
+        args={"q": "openapi"},
+        headers={"X-API-Key": "test-key"},
+    )
+    response = MockResponse(
+        data=json.dumps(
+            {
+                "data": [
+                    {
+                        "id": "1",
+                        "text": "OpenAPI",
+                        "authorUsername": "xquik",
+                    }
+                ]
+            }
+        ).encode("utf-8"),
+        status_code=200,
+        content_type="application/json",
+    )
+
+    request_result = openapi.unmarshal_request(request)
+    response_result = openapi.unmarshal_response(request, response)
+
+    assert request_result.errors == []
+    assert request_result.parameters.query["q"] == "openapi"
+    assert request_result.security == {"apiKey": "test-key"}
+    assert response_result.errors == []
+    assert response_result.data["data"][0]["authorUsername"] == "xquik"


### PR DESCRIPTION
## Summary

- Add a compact OpenAPI 3.1 fixture for the Xquik search endpoint.
- Exercise request unmarshalling, API-key security extraction, query parameters, and response unmarshalling.

## Validation

- `uv run` with Python 3.13 for `tests/integration/test_xquik.py`: 1 passed.
