### PR TITLE
Cast form values when matching allOf subschemas (#1212)

### DIFF
--- a/openapi_core/deserializing/media_types/deserializers.py
+++ b/openapi_core/deserializing/media_types/deserializers.py
@@ -379,7 +379,11 @@ class MediaTypeDeserializer:
         assert self.schema_validator is not None
 
         if not self.mimetype.startswith("multipart"):
-            return list(self.schema_validator.iter_all_of_schemas(location))
+            return list(
+                self.schema_validator.iter_all_of_schemas(
+                    location, caster=self.schema_caster
+                )
+            )
 
         if self.schema is None or "allOf" not in self.schema:
             return []

--- a/openapi_core/validation/schemas/validators.py
+++ b/openapi_core/validation/schemas/validators.py
@@ -428,6 +428,7 @@ class SchemaValidator:
     def iter_all_of_schemas(
         self,
         value: Any,
+        caster: Optional["SchemaCaster"] = None,
     ) -> Iterator[SchemaPath]:
         if "allOf" not in self.schema:
             return
@@ -438,7 +439,23 @@ class SchemaValidator:
                 continue
             validator = self.evolve(subschema)
             try:
-                validator.validate(value)
+                test_value = value
+                # Only cast if caster provided (opt-in behavior). Useful for
+                # form-encoded data where scalar values arrive as strings and
+                # need casting before validation against non-string schemas.
+                if caster is not None:
+                    try:
+                        # Convert to dict if it's not exactly a plain dict
+                        if type(value) is not dict:
+                            test_value = dict(value)
+                        else:
+                            test_value = value
+                        test_value = caster.evolve(subschema).cast(test_value)
+                    except (ValueError, TypeError, Exception):
+                        # If casting fails, validate with the original value
+                        test_value = value
+
+                validator.validate(test_value)
             except ValidateError:
                 log.warning("invalid allOf schema found")
             else:

--- a/tests/unit/deserializing/test_media_types_deserializers.py
+++ b/tests/unit/deserializing/test_media_types_deserializers.py
@@ -564,6 +564,44 @@ class TestMediaTypeDeserializer:
             "fieldA": "value",
         }
 
+    def test_urlencoded_allof_non_string_field(
+        self, spec, deserializer_factory
+    ):
+        """Test issue #1212: allOf with urlencoded must not drop a subschema
+        that has a non-string (e.g. boolean) field."""
+        mimetype = "application/x-www-form-urlencoded"
+        schema_dict = {
+            "allOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {"type": "boolean"},
+                        "label": {"type": "string"},
+                    },
+                },
+                {
+                    "type": "object",
+                    "properties": {"name": {"type": "string"}},
+                },
+            ]
+        }
+        schema = SchemaPath.from_dict(schema_dict)
+        schema_validator = oas31_schema_validators_factory.create(
+            spec, schema
+        )
+        deserializer = deserializer_factory(
+            mimetype, schema=schema, schema_validator=schema_validator
+        )
+        value = b"name=widget&label=hello&enabled=true"
+
+        result = deserializer.deserialize(value)
+
+        assert result == {
+            "name": "widget",
+            "label": "hello",
+            "enabled": True,
+        }
+
     def test_urlencoded_anyof_with_types(self, spec, deserializer_factory):
         """Test anyOf with urlencoded and type coercion"""
         mimetype = "application/x-www-form-urlencoded"


### PR DESCRIPTION
## Summary

Fixes #1212. For `application/x-www-form-urlencoded` requests, an `allOf` subschema that contains a **non-string** field (boolean, integer, object) is silently dropped — every field in that part disappears from the result, with only a `log.warning("invalid allOf schema found")` and an empty `result.errors`.

```python
# schema: allOf: [ {enabled: boolean, label: string}, {name: string} ]
# body:   name=widget&label=hello&enabled=true
result.body    # -> {'name': 'widget'}   (enabled + label lost!)
result.errors  # -> []
```

## Cause

Form values always arrive as strings. `iter_any_of_schemas` already takes an optional `caster` and coerces the value before validating each subschema (added for exactly this form-encoded case), but `iter_all_of_schemas` did not — so it validated the raw string value against the boolean/integer field, failed, and skipped the whole subschema.

## Fix

Give `iter_all_of_schemas` the same optional `caster` parameter and casting logic as `iter_any_of_schemas`, and pass `caster=self.schema_caster` from `iter_composed_all_of_schemas` in the media-type deserializer (mirroring the existing `anyOf` call).

Now the example yields `{'enabled': True, 'label': 'hello', 'name': 'widget'}`.

## Tests

- Added `test_urlencoded_allof_non_string_field`; it fails on `master` (fields dropped, warning logged) and passes here.
- `tests/unit` (excluding contrib/templating suites that need optional deps unrelated to this change) is green — 571 passed; `ruff` and `black` clean.

*Disclosure: prepared with AI assistance; reviewed and verified locally.*
