### PR TITLE
tests: fix class-scoped fixtures defined as instance methods

### DIFF
--- a/tests/unit/templating/test_media_types_finders.py
+++ b/tests/unit/templating/test_media_types_finders.py
@@ -7,18 +7,21 @@ from openapi_core.templating.media_types.finders import MediaTypeFinder
 
 class TestMediaTypes:
     @pytest.fixture(scope="class")
-    def spec(self):
+    @classmethod
+    def spec(cls):
         return {
             "application/json": {"schema": {"type": "object"}},
             "text/*": {"schema": {"type": "object"}},
         }
 
     @pytest.fixture(scope="class")
-    def content(self, spec):
+    @classmethod
+    def content(cls, spec):
         return SchemaPath.from_dict(spec)
 
     @pytest.fixture(scope="class")
-    def finder(self, content):
+    @classmethod
+    def finder(cls, content):
         return MediaTypeFinder(content)
 
     @pytest.mark.parametrize(

--- a/tests/unit/templating/test_responses_finders.py
+++ b/tests/unit/templating/test_responses_finders.py
@@ -8,7 +8,8 @@ from openapi_core.templating.responses.finders import ResponseFinder
 
 class TestResponses:
     @pytest.fixture(scope="class")
-    def spec(self):
+    @classmethod
+    def spec(cls):
         return {
             "200": mock.sentinel.response_200,
             "299": mock.sentinel.response_299,
@@ -17,11 +18,13 @@ class TestResponses:
         }
 
     @pytest.fixture(scope="class")
-    def responses(self, spec):
+    @classmethod
+    def responses(cls, spec):
         return SchemaPath.from_dict(spec)
 
     @pytest.fixture(scope="class")
-    def finder(self, responses):
+    @classmethod
+    def finder(cls, responses):
         return ResponseFinder(responses)
 
     def test_default(self, finder, responses):


### PR DESCRIPTION
pytest 9.1 deprecates class-scoped fixtures defined as plain instance methods (PytestRemovedIn10Warning): attributes set on
`self` in the fixture aren't visible to test methods, since pytest creates a new instance per test but runs the fixture only once per class.

Convert the `spec`/`content`/`finder` fixtures in
test_media_types_finders.py and the `spec`/`responses`/`finder` fixtures in test_responses_finders.py to @classmethod, per
https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method